### PR TITLE
Update to work on Python 2 and 3

### DIFF
--- a/bin/dh_virtualenv
+++ b/bin/dh_virtualenv
@@ -63,7 +63,11 @@ def main():
     if verbose:
         log.setLevel(logging.DEBUG)
 
-    dh = DebHelper(options)
+    if sys.version_info[0] == 2:
+        dh = DebHelper(options)
+    else:
+        dh = DepHelper(options.package or None)
+ 
     for package, details in dh.packages.items():
         def _info(msg):
             log.info('{0}: {1}'.format(package, msg))


### PR DESCRIPTION
With this patch I can generate a deb. It seems some of us have different /usr/share/python/debpython to you. This seems to be part of the python3 and python-minimal packages. Indeed, it looks like a python2 vs python3 issue.
