### PR TITLE
Added setuptools option

### DIFF
--- a/bin/dh_virtualenv
+++ b/bin/dh_virtualenv
@@ -46,6 +46,8 @@ def main():
                       help='do not act on the specified package')
     parser.add_option('-v', '--verbose', action='store_true',
                       default=False, help='Turn on verbose mode')
+    parser.add_option('-s', '--setuptools', action='store_true',
+                      default=False, help='Use Setuptools instead of Distribute')
     parser.add_option('--extra-index-url', action='append',
                       help='extra index URL to pass to pip.',
                       default=[])
@@ -84,6 +86,7 @@ def main():
             extra_urls=options.extra_index_url,
             preinstall=options.preinstall,
             pypi_url=options.pypi_url,
+            setuptools=options.setuptools,
             verbose=verbose,
         )
 

--- a/dh_virtualenv.py
+++ b/dh_virtualenv.py
@@ -28,7 +28,7 @@ DEFAULT_INSTALL_DIR = '/usr/share/python/'
 
 class Deployment(object):
     def __init__(self, package, extra_urls=None, preinstall=None,
-                 pypi_url=None, verbose=False):
+                 pypi_url=None, setuptools=False, verbose=False):
         self.package = package
         self.install_root = os.environ.get(ROOT_ENV_KEY, DEFAULT_INSTALL_DIR)
         root = self.install_root.lstrip('/')
@@ -41,14 +41,22 @@ class Deployment(object):
         self.pypi_url = pypi_url
         self.log_file = tempfile.NamedTemporaryFile()
         self.verbose = verbose
+        self.setuptools = setuptools
 
     def clean(self):
         shutil.rmtree(self.debian_root)
 
     def create_virtualenv(self):
-        subprocess.check_call(['virtualenv',
-                               '--no-site-packages',
-                               self.package_dir])
+        virtualenv = ['virtualenv', '--no-site-packages']
+
+        if self.setuptools:
+            virtualenv.append('--setuptools')
+
+        if self.verbose:
+            virtualenv.append('--verbose')
+
+        virtualenv.append(self.package_dir)
+        subprocess.check_call(virtualenv)
 
         # We need to prefix the pip run with the location of python
         # executable. Otherwise it would just blow up due to too long

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -85,6 +85,10 @@ few command line options:
    default will be whatever ``pip`` uses as default (usually
    ``http://pypi.python.org/simple``).
 
+.. cmdoption:: --setuptools
+
+   Use setuptools instead of distribute in the virtualenv
+
 Advanced usage
 ==============
 

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -140,6 +140,7 @@ def test_create_venv_with_verbose(callmock):
     d.create_virtualenv()
     eq_('debian/test/usr/share/python/test', d.package_dir)
     callmock.assert_called_with(['virtualenv', '--no-site-packages',
+                                 '--verbose',
                                  'debian/test/usr/share/python/test'])
     eq_(['debian/test/usr/share/python/test/bin/python',
          'debian/test/usr/share/python/test/bin/pip',
@@ -178,6 +179,22 @@ def test_create_venv_with_custom_index_url(callmock):
          '--pypi-url=http://example.com/simple',
          '--extra-index-url=foo',
          '--extra-index-url=bar',
+         '--log=foo'], d.pip_prefix)
+
+
+@patch('tempfile.NamedTemporaryFile', FakeTemporaryFile)
+@patch('subprocess.check_call')
+def test_create_venv_with_setuptools(callmock):
+    d = Deployment('test', setuptools=True)
+    d.create_virtualenv()
+    eq_('debian/test/usr/share/python/test', d.package_dir)
+    callmock.assert_called_with(['virtualenv', '--no-site-packages',
+                                 '--setuptools',
+                                 'debian/test/usr/share/python/test'])
+    eq_(['debian/test/usr/share/python/test/bin/python',
+         'debian/test/usr/share/python/test/bin/pip',
+         '-v',
+         'install',
          '--log=foo'], d.pip_prefix)
 
 


### PR DESCRIPTION
Added the option `--setuptools` which passes that switch to `virtualenv` (by default it uses `distribute`). This is useful for some packages which require a newer version of `distribute` than is contained within the default `virtualenv` package (eg `MySQL-python`).
