### PR TITLE
Add warning about tab identation in rules

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -101,7 +101,10 @@ for that is fairly straightforward:
   #!/usr/bin/make -f
 
   %:
-      dh $@ --with python-virtualenv
+  	dh $@ --with python-virtualenv
+
+**Warning**: Use a tab character to indent ``dh $@ --with python-virtualenv`` line. Otherwise, you will have this error during the build: ``debian/rules:4: *** 
+missing separator.  Stop.``
 
 And there we go, debianization of your new package is ready!
 


### PR DESCRIPTION
I've added a warning in documentation about tab identation in rules file to avoid others waste their time about this Makefile detail.
