### PR TITLE
Change architecture to any, because .deb package generated is target dependent

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -70,7 +70,7 @@ project is about, a file called ``control``. Enter a following
    Standards-Version: 3.9.5
 
    Package: my-awesome-python-software
-   Architecture: all
+   Architecture: any
    Depends: ${python:Depends}, ${misc:Depends}
    Description: really neat package!
     second line can contain extra information about it.


### PR DESCRIPTION
As explained in this documentation: https://wiki.debian.org/IntroDebianPackaging:

```
"Architecture:"
tells which computer architectures the binary package is expected to work on: i386 for 32-bit Intel CPUs, amd64 for 64-bit, armel for ARM processors, and so on. Debian works on about a dozen computer architectures in total, so this architecture support is crucial. The "Architecture:" field can contain names of particular architectures, but usually it contains one of two special values.
"any"
(which we see in the example) means that the package can be built for any architecture. In other words, the code has been written portably, so it does not make too many assumptions about the hardware. However, the binary package will still need to be built for each architecture separately.
"all"
means that the same binary package will work on all architectures, without having to be built separately for each. For example, a package consisting only of shell scripts would be "all". Shell scripts work the same everywhere and not need to be compiled.
```
