### PR TITLE
Fix VIRTUAL_ENV path in bin/activate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,9 @@
 .#*
 *#
 
+# Build files
+build/
+dh_virtualenv.egg-info/
+
 # Sphinx build
 doc/_build

--- a/bin/dh_virtualenv
+++ b/bin/dh_virtualenv
@@ -98,6 +98,7 @@ def main():
         deploy.install_dependencies()
         deploy.install_package()
         deploy.fix_shebangs()
+        deploy.fix_activate_path()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This resolves issue #17 - rewrite the virtualenv path to the system path

I also lowered the debhelper dependency to 7 (because I only had 7.4 installed). This seemed to work for me, I was able to package it just fine.  If I've missed something let me know and I can revert that part of the change.
