### PR TITLE
Update tutorial documentation to work with Ubuntu 12.04

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -18,11 +18,11 @@ after you have cloned the repository are:
 
 .. code-block:: bash
 
-   sudo apt-get install devscripts python-virtualenv git  # Install needed packages
-   git clone https://github.com/spotify/dh-virtualenv.git # Clone Git repository
-   cd dh-virtualenv                                       # Move into the repository
-   sudo mk-build-deps -ri                                 # This will install build dependencies
-   dpkg-buildpackage -us -uc                              # Build the *dh-virtualenv* package
+   sudo apt-get install devscripts python-virtualenv git equivs # Install needed packages
+   git clone https://github.com/spotify/dh-virtualenv.git       # Clone Git repository
+   cd dh-virtualenv                                             # Move into the repository
+   sudo mk-build-deps -ri                                       # This will install build dependencies
+   dpkg-buildpackage -us -uc -b                                 # Build the *dh-virtualenv* package
 
    # and finally, install it (you might have to solve some
    # dependencies when doing this):


### PR DESCRIPTION
There could be a better solution here then just building as a binary package, but here are the two problems I just ran into when installing this on Ubuntu 12.04:
##### equiv not installed

Easy enough, I saw there was another pull request that had this + some other stuff in it as well after the fact, but included it in here anyway.

```
$ sudo mk-build-deps -ri
mk-build-deps: You must have equivs installed to use this program.
```
##### no upstream tarball found

```
$ dpkg-buildpackage -us -uc
dpkg-buildpackage: source package dh-virtualenv
dpkg-buildpackage: source version 0.6-1
dpkg-buildpackage: source changed by Jyrki Pulliainen <jyrki@spotify.com>
dpkg-buildpackage: host architecture amd64
 dpkg-source --before-build dh-virtualenv
 fakeroot debian/rules clean

-- snip --

dh clean --with python2 --with sphinxdoc
   dh_testdir
   dh_auto_clean
running clean
'build/lib.linux-x86_64-2.7' does not exist -- can't clean it
'build/bdist.linux-x86_64' does not exist -- can't clean it
'build/scripts-2.7' does not exist -- can't clean it
   dh_clean
 dpkg-source -b dh-virtualenv
dpkg-source: error: can't build with source format '3.0 (quilt)': no upstream tarball found at ../dh-virtualenv_0.6.orig.tar.{bz2,gz,lzma,xz}
dpkg-buildpackage: error: dpkg-source -b dh-virtualenv gave error exit status 255
debuild: fatal error at line 1350:
dpkg-buildpackage -rfakeroot -D -us -uc failed
```

Let me know if there is a better solution, or just something that I have missed :)
