### PR TITLE
JoshK/TomC: fix default for --no-test flag in DebhelperOptionParser

### DIFF
--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -63,7 +63,8 @@ def get_default_parser():
                       help='The source directory')
     parser.add_option('--no-test', action='store_false', dest='test',
                       help="Don't run tests for the package. Useful "
-                      "for example when you have packaged with distutils.")
+                      "for example when you have packaged with distutils.",
+                      default=True)
 
     # Ignore user-specified option bundles
     parser.add_option('-O', help=SUPPRESS_HELP)

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -55,3 +55,15 @@ def test_get_default_parser():
     ])
     eq_('/tmp/foo', opts.sourcedirectory)
     eq_(['http://example.com'], opts.extra_index_url)
+
+
+def test_that_default_test_option_should_be_true():
+    parser = cmdline.get_default_parser()
+    opts, args = parser.parse_args()
+    eq_(True, opts.test)
+
+
+def test_that_test_option_can_be_false():
+    parser = cmdline.get_default_parser()
+    opts, args = parser.parse_args(['--no-test'])
+    eq_(False, opts.test)


### PR DESCRIPTION
This should fix #34. What do you think?
