### PR TITLE
Support the built-in venv module on Python 3.4+

### DIFF
--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -59,6 +59,9 @@ def get_default_parser():
                       default=[])
     parser.add_option('--pypi-url', help='Base URL of the PyPI server')
     parser.add_option('--python', help='The Python to use')
+    parser.add_option('--builtin-venv', action='store_true',
+                      help='Use the built-in venv module. Only works on '
+                      'Python 3.4 and later.')
     parser.add_option('-D', '--sourcedirectory', dest='sourcedirectory',
                       help='The source directory')
     parser.add_option('--no-test', action='store_false', dest='test',

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -101,6 +101,15 @@ few command line options:
    interpreter for the virtualenv. Default is to use the system
    default, usually ``/usr/bin/python``.
 
+.. cmdoption:: --builtin-venv
+
+   Enable the use of the build-in ``venv`` module, i.e. use ``python
+   -m venv`` to create the virtualenv. For this to work, requires
+   Python 3.4 or later to be used, e.g. by using the option ``--python
+   /usr/bin/python3.4``. (Python 3.3 has the ``venv`` module, but
+   virtualenvs created with Python 3.3 are not bootstrapped with
+   setuptools or pip.)
+
 
 Advanced usage
 ==============


### PR DESCRIPTION
Add command line option --builtin-venv that enables the use of the
built-in venv module. It should only be used for Python 3.4 and later
that bootstrap the new virtualenv with setuptools and pip.
