### PR TITLE
doc: no python2.x-minimal per lintian

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -71,7 +71,7 @@ project is about, a file called ``control``. Enter a following
 
    Package: my-awesome-python-software
    Architecture: any
-   Pre-Depends: dpkg (>= 1.16.1), python2.7-minimal | python2.6-minimal, ${misc:Pre-Depends}
+   Pre-Depends: dpkg (>= 1.16.1), python2.7 | python2.6, ${misc:Pre-Depends}
    Depends: ${python:Depends}, ${misc:Depends}
    Description: really neat package!
     second line can contain extra information about it.


### PR DESCRIPTION
The tutorial documentation instructs to use python2.x-minimal in the
binary package Pre-Depends. That raise a lintian error for me:

    E: zuul: depends-on-python-minimal pre-depends

    The python-minimal package (and versioned variants thereof) exists
    only to possibly become an Essential package. Depending on it is
    always an error since it should never be installed without python.
    If it becomes Essential, there is no need to depend on it, and until
    then, packages that require Python must depend on python.

In the tutorial, replace Pre-Depends python2.x-minimal with python2.x.