### PR TITLE
git-buildpackage default configuration

### DIFF
--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -1,0 +1,3 @@
+[git-buildpackage]
+ignore-branch = True
+debian-branch = HEAD


### PR DESCRIPTION
The debian source files are in the same branch as the source code so it
should just look at HEAD saving us from having to pass
--git-debian-branch.

Set debian-branch to HEAD.
Since gbp does not match the current branch with HEAD, ignore-branch.