### PR TITLE
debian: enhance clean target dependencies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dh-virtualenv (0.9-1.1) UNRELEASED; urgency=medium
+
+  * Non-maintainer upload.
+  * Add dh-python to Build-Depends, it might not always be available on the
+    build machine and that causes a warning:
+        W: dh_python2:479: Please add dh-python package to Build-Depends
+  * debian/rules now have a standard clean target.
+
+ -- Antoine Musso <hashar@free.fr>  Mon, 23 Mar 2015 13:34:41 +0100
+
 dh-virtualenv (0.9-1) experimental; urgency=low
 
   * New upstream release

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: dh-virtualenv
 Section: python
 Priority: extra
 Maintainer: Jyrki Pulliainen <jyrki@spotify.com>
-Build-Depends: debhelper (>= 9), python(>= 2.6.6-3~),
+Build-Depends: debhelper (>= 9), python(>= 2.6.6-3~), dh-python,
  python-setuptools, python-sphinx, python-mock
 Standards-Version: 3.9.6
 Homepage: http://www.github.com/spotify/dh-virtualenv

--- a/debian/rules
+++ b/debian/rules
@@ -3,6 +3,13 @@
 %:
 	dh $@ --with python2 --with sphinxdoc
 
+# Work around dh-python/sphinxdoc helpers which might not be available on the
+# build machine since clean is executed outside of pbuilder chroot.
+clean:
+	dh_testdir
+	dh_auto_clean
+	dh_clean
+
 override_dh_auto_clean:
 	rm -rf doc/_build
 	rm -f doc/dh_virtualenv.1


### PR DESCRIPTION
When building a package with pbuilder, the clean target is run outside
of the chroot. That causes unmet build dependencies with
python-sphinxdoc and python-mock.  They are only needed for the binary
package but Debian does not have a way to set different dependencies to
build the source package.

Use a standard clean target so pbuilder does not complain about unmet
build dependencies
Add dh-python to build dependencies. On Jessie, it is a dependencies of
the python3 package, but might not always be installed nonetheless.

Signed-off-by: Alexandros Kosiaris <akosiaris@gmail.com>