### PR TITLE
tutorial.rst: Add newline to «pkgname».triggers

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -89,7 +89,10 @@ interpreter in case of updates, create a file named
 ``debian/«pkgname».triggers``, where ``«pkgname»`` is what you
 named your package in the ``control`` file. It triggers a special script
 whenever the Python binary changes; don't worry, that script is provided
-by ``dh-virtualenv`` automatically.
+by ``dh-virtualenv`` automatically. Your ``«pkgname».triggers`` file 
+should end with a newline, otherwise you might get this error from dpkg:
+``too-long line or missing newline in `/var/lib/dpkg/tmp.ci/triggers'``
+when installing your package.
 
 .. code-block:: «pkgname».triggers
 


### PR DESCRIPTION
Ran into issues when installing my package, giving me error:

```
dpkg: error processing archive my-package_0.0.7_amd64.deb (--install):
 too-long line or missing newline in `/var/lib/dpkg/tmp.ci/triggers'
```

when installing the package on the host. Turns out you need to end your triggers file with a newline (at least on my Debian 7.8, Linux debian 3.2.0-4-amd64 #1 SMP Debian 3.2.65-1+deb7u2 x86_64 GNU/Linux)

Updated tutorial to reflect this
