### PR TITLE
Override build system settings with environment variables

### DIFF
--- a/doc/info.rst
+++ b/doc/info.rst
@@ -24,6 +24,13 @@ In the sequence the ``dh_virtualenv`` is inserted right after
 Following list contains most notable changes by version. For full list
 consult the git history of the project.
 
+0.10
+====
+
+* Honor ``DH_VIRTUALENV_INSTALL_ROOT`` in build system
+* Allow overriding virtualenv arguments by using the
+  ``DH_VIRTUALENV_ARGUMENTS`` environment variable when using the build system
+
 0.9
 ===
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -197,6 +197,16 @@ In addition the separation of build and install steps makes it
 possible to use ``debian/install`` files to include built files into
 the Debian package. This is not possible with the sequencer addition.
 
+The build system honors the ``DH_VIRTUALENV_INSTALL_ROOT`` environment
+variable. Arguments can be passed to virtualenv by setting
+``DH_VIRTUALENV_ARGUMENTS``. For example:
+
+.. code-block:: make
+
+  export DH_VIRTUALENV_ARGUMENTS=--no-site-packages --always-copy
+
+The default is to create the virtual environment with ``--no-site-packages``.
+
 Known incompabilities of the buildsystem
 ----------------------------------------
 
@@ -208,4 +218,3 @@ most of them, if not all, probably will.
 * ``Pyvenv`` of Python 3.x is not supported
 * No custom arguments outside requirements.txt can be passed to
   ``pip``
-* Not possible to specify custom install or build directories


### PR DESCRIPTION
Honor ``DH_VIRTUALENV_INSTALL_ROOT`` in build system so that one can override the destination path the same way as with the sequencer approach. I also introduced a new variable ``DH_VIRTUALENV_ARGUMENTS`` to allow overriding virtualenv arguments, e.g. to be able to create non-symlinked packages by passing ``--always-copy`` to virtualenv.

Is that something you'd want to integrate?

There will be conflicts https://github.com/spotify/dh-virtualenv/pull/87. I can update/rebase this pull request if you want to merge that one first.