### PR TITLE
Add an environment variable to be able to change the virtualenv folder name

### DIFF
--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -25,6 +25,7 @@ import tempfile
 
 ROOT_ENV_KEY = 'DH_VIRTUALENV_INSTALL_ROOT'
 DEFAULT_INSTALL_DIR = '/usr/share/python/'
+ENV_PATH_KEY = 'DH_VIRTUALENV_ENV_PATH'
 
 
 class Deployment(object):
@@ -33,7 +34,7 @@ class Deployment(object):
                  builtin_venv=False, sourcedirectory=None, verbose=False,
                  extra_pip_arg=[], use_system_packages=False):
 
-        self.package = package
+        self.package = os.environ.get(ENV_PATH_KEY, package)
         install_root = os.environ.get(ROOT_ENV_KEY, DEFAULT_INSTALL_DIR)
         self.virtualenv_install_dir = os.path.join(install_root, self.package)
         self.debian_root = os.path.join(

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -34,7 +34,8 @@ class Deployment(object):
                  builtin_venv=False, sourcedirectory=None, verbose=False,
                  extra_pip_arg=[], use_system_packages=False):
 
-        self.package = os.environ.get(ENV_PATH_KEY, package)
+        package = os.environ.get(ENV_PATH_KEY, package)
+        self.package = package
         install_root = os.environ.get(ROOT_ENV_KEY, DEFAULT_INSTALL_DIR)
         self.virtualenv_install_dir = os.path.join(install_root, self.package)
         self.debian_root = os.path.join(

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -34,13 +34,13 @@ class Deployment(object):
                  builtin_venv=False, sourcedirectory=None, verbose=False,
                  extra_pip_arg=[], use_system_packages=False):
 
-        package = os.environ.get(ENV_PATH_KEY, package)
+        self.virtualenv_name = os.environ.get(ENV_PATH_KEY, package)
         self.package = package
         install_root = os.environ.get(ROOT_ENV_KEY, DEFAULT_INSTALL_DIR)
-        self.virtualenv_install_dir = os.path.join(install_root, self.package)
+        self.virtualenv_install_dir = os.path.join(install_root, self.virtualenv_name)
         self.debian_root = os.path.join(
             'debian', package, install_root.lstrip('/'))
-        self.package_dir = os.path.join(self.debian_root, package)
+        self.package_dir = os.path.join(self.debian_root, self.virtualenv_name)
         self.bin_dir = os.path.join(self.package_dir, 'bin')
         self.local_bin_dir = os.path.join(self.package_dir, 'local', 'bin')
 

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -379,7 +379,7 @@ def test_deployment_from_options_with_verbose_from_env(env_mock):
         env_mock.return_value = '1'
         options, _ = get_default_parser().parse_args([])
         d = Deployment.from_options('foo', options)
-        eq_(d.package, 'foo')
+        eq_(d.package, '1')
         eq_(d.verbose, True)
 
 


### PR DESCRIPTION
I was needing to put the virtualenv in a hidden folder. Adding an environment variable was the easiest way to do that.