### PR TITLE
 - Added option to specify a custom suffix for the installation path instead of the package name

### DIFF
--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -80,6 +80,9 @@ def get_default_parser():
                       help="Set the --system-site-packages flag in virtualenv "
                            "creation, allowing you to use system packages.",
                       default=False)
+    parser.add_option('--install-suffix', 
+                      dest='install_suffix',
+                      help="Override installation path suffix");
 
     # Ignore user-specified option bundles
     parser.add_option('-O', help=SUPPRESS_HELP)

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -31,14 +31,23 @@ class Deployment(object):
     def __init__(self, package, extra_urls=[], preinstall=[],
                  pypi_url=None, setuptools=False, python=None,
                  builtin_venv=False, sourcedirectory=None, verbose=False,
-                 extra_pip_arg=[], use_system_packages=False):
+                 extra_pip_arg=[], use_system_packages=False, 
+                 install_suffix=None):
 
         self.package = package
         install_root = os.environ.get(ROOT_ENV_KEY, DEFAULT_INSTALL_DIR)
-        self.virtualenv_install_dir = os.path.join(install_root, self.package)
+        self.install_suffix = install_suffix
+
         self.debian_root = os.path.join(
             'debian', package, install_root.lstrip('/'))
-        self.package_dir = os.path.join(self.debian_root, package)
+
+        if install_suffix is None:
+            self.virtualenv_install_dir = os.path.join(install_root, self.package)
+            self.package_dir = os.path.join(self.debian_root, package)
+        else:
+            self.virtualenv_install_dir = os.path.join(install_root, install_suffix)
+            self.package_dir = os.path.join(self.debian_root, install_suffix)
+            
         self.bin_dir = os.path.join(self.package_dir, 'bin')
         self.local_bin_dir = os.path.join(self.package_dir, 'local', 'bin')
 
@@ -67,7 +76,9 @@ class Deployment(object):
                    sourcedirectory=options.sourcedirectory,
                    verbose=verbose,
                    extra_pip_arg=options.extra_pip_arg,
-                   use_system_packages=options.use_system_packages)
+                   use_system_packages=options.use_system_packages,
+                   dependencies_only=options.dependencies_only,
+                   install_suffix=options.install_suffix)
 
     def clean(self):
         shutil.rmtree(self.debian_root)

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -77,7 +77,6 @@ class Deployment(object):
                    verbose=verbose,
                    extra_pip_arg=options.extra_pip_arg,
                    use_system_packages=options.use_system_packages,
-                   dependencies_only=options.dependencies_only,
                    install_suffix=options.install_suffix)
 
     def clean(self):

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -10,7 +10,7 @@ By default, *dh-virtualenv* installs your packages under
 ``/usr/share/python/<packagename>``. The package name is provided by
 the ``debian/control`` file.
 
-To use an alternative install path, add a line like
+To use an alternative install prefix, add a line like
 
 .. code-block:: make
 
@@ -19,6 +19,11 @@ To use an alternative install path, add a line like
 to the top of your ``debian/rules`` file. dh_virtualenv will use
 DH_VIRTUALENV_INSTALL_ROOT instead of ``/usr/share/python`` when it
 constructs the install path.
+
+To use an install suffix other than the package name, call the 
+``dh_virtualenv`` command using with the ``--install-suffix`` 
+command line option. See Advanced Usage for further information
+on passing options.
 
 Simple usecase
 ==============
@@ -69,6 +74,13 @@ few command line options:
    level to ``DEBUG`` and passes verbose flag to ``pip`` when
    installing packages. This can also be provided using the standard
    ``DH_VERBOSE`` environment variable.
+
+.. cmdoption:: --install-suffix <suffix>
+
+   Override virtualenv installation suffix. The suffix is appended to
+   ``/usr/share/python``, or the ``DH_VIRTUALENV_INSTALL_ROOT``
+   environment variable if specified, to construct the installation
+   path.
 
 .. cmdoption:: --extra-index-url <url>
 


### PR DESCRIPTION
I work with an environment where the venv needs to follow existing naming conventions, and the path $DH_VIRTUALENV_INSTALL_ROOT/[packagename] does not comply.

This patch allows the user to do the following:

```
export DH_VIRTUALENV_INSTALL_ROOT=/srv/www/app/

binary:
[snip]
    dh_virtualenv --install-suffix=venv
```

and the resulting venv should be /srv/www/app/venv/
