### PR TITLE
 - Added option to only install dependencies for packages where only a virtualenv containing dependencies is required

### DIFF
--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -80,10 +80,10 @@ def get_default_parser():
                       help="Set the --system-site-packages flag in virtualenv "
                            "creation, allowing you to use system packages.",
                       default=False)
-    parser.add_option('--dependencies-only', action='store_true',
+    parser.add_option('--skip-install', action='store_true',
                       default=False, 
-                      dest='dependencies_only',
-                      help="Install dependencies only");
+                      dest='skip_install',
+                      help="Skip running pip install within the source directory.");
     
     # Ignore user-specified option bundles
     parser.add_option('-O', help=SUPPRESS_HELP)

--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -80,7 +80,11 @@ def get_default_parser():
                       help="Set the --system-site-packages flag in virtualenv "
                            "creation, allowing you to use system packages.",
                       default=False)
-
+    parser.add_option('--dependencies-only', action='store_true',
+                      default=False, 
+                      dest='dependencies_only',
+                      help="Install dependencies only");
+    
     # Ignore user-specified option bundles
     parser.add_option('-O', help=SUPPRESS_HELP)
     parser.add_option('-a', '--arch', dest="arch",

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -31,7 +31,8 @@ class Deployment(object):
     def __init__(self, package, extra_urls=[], preinstall=[],
                  pypi_url=None, setuptools=False, python=None,
                  builtin_venv=False, sourcedirectory=None, verbose=False,
-                 extra_pip_arg=[], use_system_packages=False):
+                 extra_pip_arg=[], use_system_packages=False, 
+                 dependencies_only=False):
 
         self.package = package
         install_root = os.environ.get(ROOT_ENV_KEY, DEFAULT_INSTALL_DIR)
@@ -53,7 +54,8 @@ class Deployment(object):
         self.builtin_venv = builtin_venv
         self.sourcedirectory = '.' if sourcedirectory is None else sourcedirectory
         self.use_system_packages = use_system_packages
-
+        self.dependencies_only = dependencies_only
+        
     @classmethod
     def from_options(cls, package, options):
         verbose = options.verbose or os.environ.get('DH_VERBOSE') == '1'
@@ -67,7 +69,8 @@ class Deployment(object):
                    sourcedirectory=options.sourcedirectory,
                    verbose=verbose,
                    extra_pip_arg=options.extra_pip_arg,
-                   use_system_packages=options.use_system_packages)
+                   use_system_packages=options.use_system_packages,
+                   dependencies_only=options.dependencies_only)
 
     def clean(self):
         shutil.rmtree(self.debian_root)
@@ -179,7 +182,8 @@ class Deployment(object):
             fh.write(content)
 
     def install_package(self):
-        subprocess.check_call(self.pip('.'), cwd=os.path.abspath(self.sourcedirectory))
+        if self.dependencies_only is not True:
+            subprocess.check_call(self.pip('.'), cwd=os.path.abspath(self.sourcedirectory))
 
     def fix_local_symlinks(self):
         # The virtualenv might end up with a local folder that points outside the package

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -32,7 +32,7 @@ class Deployment(object):
                  pypi_url=None, setuptools=False, python=None,
                  builtin_venv=False, sourcedirectory=None, verbose=False,
                  extra_pip_arg=[], use_system_packages=False, 
-                 dependencies_only=False):
+                 skip_install=False):
 
         self.package = package
         install_root = os.environ.get(ROOT_ENV_KEY, DEFAULT_INSTALL_DIR)
@@ -54,7 +54,7 @@ class Deployment(object):
         self.builtin_venv = builtin_venv
         self.sourcedirectory = '.' if sourcedirectory is None else sourcedirectory
         self.use_system_packages = use_system_packages
-        self.dependencies_only = dependencies_only
+        self.skip_install = skip_install
         
     @classmethod
     def from_options(cls, package, options):
@@ -70,7 +70,7 @@ class Deployment(object):
                    verbose=verbose,
                    extra_pip_arg=options.extra_pip_arg,
                    use_system_packages=options.use_system_packages,
-                   dependencies_only=options.dependencies_only)
+                   skip_install=options.skip_install)
 
     def clean(self):
         shutil.rmtree(self.debian_root)
@@ -182,7 +182,7 @@ class Deployment(object):
             fh.write(content)
 
     def install_package(self):
-        if self.dependencies_only is not True:
+        if not self.skip_install:
             subprocess.check_call(self.pip('.'), cwd=os.path.abspath(self.sourcedirectory))
 
     def fix_local_symlinks(self):

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -135,6 +135,22 @@ few command line options:
    Enable the use of system site-packages in the created virtualenv
    by passing the ``--system-site-packages`` flag to ``virtualenv``.
 
+.. cmdoption:: --skip-install
+
+   Skip running ``pip install .`` after dependencies have been
+   installed. This will result in anything specified in setup.py being
+   ignored. If this package is intended to install a virtualenv
+   and a program that uses the supplied virtualenv, it is up to
+   the user to ensure that if setup.py exists, any installation logic
+   or dependencies contained therein are handled.
+
+   This option is useful for web application deployments where the
+   package is expected contain the virtual environment to support
+   an application which itself may be installed via some other means
+   -- typically, by the packages ``./debian/<packagename>.install``
+   file, possibly into a directory structure unrelated to the location
+   of the virtual environment.
+
 
 Advanced usage
 ==============


### PR DESCRIPTION
I work with an environment where the virtualenv only contains dependencies for the application, the actual application code is deployed separately. 

This change allows the user to specify --dependencies-only - this results in no action being taken by deploy.install_package()