### PR TITLE
Allow a explicit filename for 'requirements.txt'

### DIFF
--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -81,12 +81,16 @@ def get_default_parser():
                            "creation, allowing you to use system packages.",
                       default=False)
     parser.add_option('--skip-install', action='store_true',
-                      default=False, 
+                      default=False,
                       dest='skip_install',
                       help="Skip running pip install within the source directory.");
-    parser.add_option('--install-suffix', 
+    parser.add_option('--install-suffix',
                       dest='install_suffix',
                       help="Override installation path suffix");
+    parser.add_option('--requirements',
+                      dest='requirements_filename',
+                      help='Specify the filename for requirementst.txt',
+                      default='requirements.txt')
 
     # Ignore user-specified option bundles
     parser.add_option('-O', help=SUPPRESS_HELP)

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -33,7 +33,8 @@ class Deployment(object):
                  builtin_venv=False, sourcedirectory=None, verbose=False,
                  extra_pip_arg=[], use_system_packages=False,
                  skip_install=False,
-                 install_suffix=None):
+                 install_suffix=None,
+                 requirements_filename='requirements.txt'):
 
         self.package = package
         install_root = os.environ.get(ROOT_ENV_KEY, DEFAULT_INSTALL_DIR)
@@ -64,6 +65,7 @@ class Deployment(object):
         self.sourcedirectory = '.' if sourcedirectory is None else sourcedirectory
         self.use_system_packages = use_system_packages
         self.skip_install = skip_install
+        self.requirements_filename = requirements_filename
 
     @classmethod
     def from_options(cls, package, options):
@@ -80,7 +82,8 @@ class Deployment(object):
                    extra_pip_arg=options.extra_pip_arg,
                    use_system_packages=options.use_system_packages,
                    skip_install=options.skip_install,
-                   install_suffix=options.install_suffix)
+                   install_suffix=options.install_suffix,
+                   requirements_filename=options.requirements_filename)
 
     def clean(self):
         shutil.rmtree(self.debian_root)
@@ -142,7 +145,7 @@ class Deployment(object):
         if self.preinstall:
             subprocess.check_call(self.pip(*self.preinstall))
 
-        requirements_path = os.path.join(self.sourcedirectory, 'requirements.txt')
+        requirements_path = os.path.join(self.sourcedirectory, self.requirements_filename)
         if os.path.exists(requirements_path):
             subprocess.check_call(self.pip('-r', requirements_path))
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -116,6 +116,15 @@ few command line options:
    override_dh_virtualenv section of the debian/rules file will
    disable the generation of pyc files.
 
+.. cmdoption:: --requirements <REQUIREMENTS FILE>
+
+   Use a different requirements file when installing. Some packages
+   such as `pbr <http://docs.openstack.org/developer/pbr/>`_ expect
+   the ``requirements.txt`` file to be a simple list of requirements
+   that can be copied verbatim into the ``install_requires``
+   list. This command option allows specifying a different
+   ``requirements.txt`` file that may include pip specific flags such
+   as ``-i``, ``-r-`` and ``-e``.
 
 .. cmdoption:: --setuptools
 


### PR DESCRIPTION
- Add --requirements-filename flag
 - use the provided requirements_filename in Deployment

The default is 'requirements.txt', which should be backwards
compatible.

Fixes: #117 