### PR TITLE
Ensure that our venv is configured before we try and start any daemons.

### DIFF
--- a/lib/Debian/Debhelper/Sequence/python_virtualenv.pm
+++ b/lib/Debian/Debhelper/Sequence/python_virtualenv.pm
@@ -23,7 +23,7 @@ use warnings;
 use strict;
 use Debian::Debhelper::Dh_Lib;
 
-insert_after("dh_perl", "dh_virtualenv");
+insert_before("dh_installinit", "dh_virtualenv");
 
 # dh_auto_test can cause system python to run 'python setup.py test',
 # which will break due missing dependencies.


### PR DESCRIPTION
This is to ensure a consistent environment from the 1st and nth install
of a package - currently `invoke-rc.d daemon start` is called before we
have run our interpreter updates.

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>