### PR TITLE
Buildsystem: Split venv creation and package installation

### DIFF
--- a/lib/Debian/Debhelper/Buildsystem/dh_virtualenv.pm
+++ b/lib/Debian/Debhelper/Buildsystem/dh_virtualenv.pm
@@ -108,10 +108,6 @@ sub build {
     }
     $this->doit_in_sourcedir(
         $python, $pip, 'install', '-r', $reqfile, @pipargs);
-
-    $this->doit_in_sourcedir(
-        $python, $pip, 'install', '.');
-
 }
 
 sub test {
@@ -129,6 +125,9 @@ sub install {
     my $sourcepackage = $this->sourcepackage();
     my $venv = $this->get_venv_builddir();
     my $prefix = $this->get_install_root();
+
+    $this->doit_in_sourcedir(
+        $python, $pip, 'install', '.');
 
     # Before we copy files, let's make the symlinks in the 'usr/local'
     # relative to the build path.


### PR DESCRIPTION
Post-pone moving sources into build folder from build to install step. This allows running commands (via `override_dh_auto_build`) inside the source folder after preparing the virtual environment but before moving the package itself into the build folder.

For example, this way I can compile PO files in the source folder (using the virtualenv in the build folder) and let the MANIFEST.in take care of moving the MO files into the build folder during installation.

Does that make sense or am I missing something?