### PR TITLE
Unittesting improvements

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = dh_virtualenv

--- a/.noserc
+++ b/.noserc
@@ -1,0 +1,4 @@
+[nosetests]
+verbosity=1
+with-coverage=1
+cover-package=dh_virtualenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 
 python:
   - "2.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 sudo: false
+cache: pip
 
 python:
   - "2.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: python
+
 python:
   - "2.6"
   - "2.7"
-install: "pip install -r travis-requirements.txt"
+
+install:
+  - cp .noserc $HOME/
+  - pip install -r travis-requirements.txt
+
 script: nosetests
+
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-# dh-virtualenv
-
-[![Build Status](https://travis-ci.org/spotify/dh-virtualenv.png)](https://travis-ci.org/spotify/dh-virtualenv)
+dh-virtualenv [![Build Status](https://travis-ci.org/spotify/dh-virtualenv.png)](https://travis-ci.org/spotify/dh-virtualenv) [![Coverage Status](https://coveralls.io/repos/spotify/dh-virtualenv/badge.svg?branch=unittesting-improvements&service=github)](https://coveralls.io/github/spotify/dh-virtualenv?branch=unittesting-improvements)
+==========
 
 dh-virtualenv is a tool that aims to combine Debian packaging with
 self-contained virtualenv based Python deployments.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-dh-virtualenv [![Build Status](https://travis-ci.org/spotify/dh-virtualenv.png)](https://travis-ci.org/spotify/dh-virtualenv) [![Coverage Status](https://coveralls.io/repos/spotify/dh-virtualenv/badge.svg?branch=unittesting-improvements&service=github)](https://coveralls.io/github/spotify/dh-virtualenv?branch=unittesting-improvements)
+dh-virtualenv [![Build Status](https://travis-ci.org/spotify/dh-virtualenv.png)](https://travis-ci.org/spotify/dh-virtualenv) [![Coverage Status](https://coveralls.io/repos/spotify/dh-virtualenv/badge.svg?branch=master&service=github)](https://coveralls.io/github/spotify/dh-virtualenv?branch=master)
 ==========
 
 dh-virtualenv is a tool that aims to combine Debian packaging with

--- a/travis-requirements.txt
+++ b/travis-requirements.txt
@@ -5,3 +5,4 @@ Sphinx==1.2
 docutils==0.11
 mock==1.0.1
 nose==1.3.0
+coveralls==1.1


### PR DESCRIPTION
This pull requests apply the following improvements:
- codecoverage is now tracked using nodetests --with-coverage and results are published on coveralls.io: 
- the travisCI environment has been migrated to the [container-based infrastructure](https://docs.travis-ci.com/user/workers/container-based-infrastructure/)
- pip pachages are now cached by travis in order to speedup builds and reduce travis overheads
- the readme has been updated exposing coveralls badge


The following is the output that will be available after the merge:

https://travis-ci.org/evilaliv3/dh-virtualenv/jobs/101411288
https://coveralls.io/github/evilaliv3/dh-virtualenv

![screenshot from 2016-01-10 15 19 57](https://cloud.githubusercontent.com/assets/217034/12222055/ca175e02-b7b0-11e5-957c-d711772d3406.png)

![screenshot from 2016-01-10 15 33 28](https://cloud.githubusercontent.com/assets/217034/12222057/d06767fc-b7b0-11e5-9bec-f1876b4f6151.png)

![screenshot from 2016-01-10 15 37 56](https://cloud.githubusercontent.com/assets/217034/12222060/d79f9288-b7b0-11e5-8392-3ffcaabcc751.png)