### PR TITLE
Extend shebang fixing for multiple interpreters

### DIFF
--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -96,7 +96,7 @@ def check_shebangs_fix(interpreter, path):
     expected_shebang = '#!' + os.path.join(path, 'bin/python') + '\n'
 
     with open(temp.name, 'w') as f:
-        f.write('#!/usr/bin/{}\n'.format(interpreter))
+        f.write('#!/usr/bin/{0}\n'.format(interpreter))
 
     deployment.fix_shebangs()
 
@@ -104,7 +104,7 @@ def check_shebangs_fix(interpreter, path):
         eq_(f.read(), expected_shebang)
 
     with open(temp.name, 'w') as f:
-        f.write('#!/usr/bin/env {}\n'.format(interpreter))
+        f.write('#!/usr/bin/env {0}\n'.format(interpreter))
 
     deployment.fix_shebangs()
 


### PR DESCRIPTION
This change should fix all problems with packaged virtualenvs that where
created using pypy or other non-default interpreter.

It allows multiple alternative python interpreters to be used when
creating a virtualenv by substituting from a list with all known python
interpreter names AFAIK.

Currently the `Deployment.fix_shebangs` only searches and changes
shebangs which are pointing to the default python interpreter
using this regex:

    ^#!.*bin/\(env \)\?python

This conflicts with virtualenvs created using a different interpreter
(eg: `pypy`), where virtualenv creates files adding shebangs pointing to
`/path/to/venv/bin/pypy` that don't get rewrited to
`/deployment/path/bin/python` by dh-virtualenv as they should as they don't match the original regular expression.

A possible drawback could be the undesired rewrite of scripts present en /bin but not intended as part of the virtualenv, but left there by setuptools as static files. This is not specific of this change, but widens the set of possibly affected scripts.