### PR TITLE
Adds tox configuration for py26/py27 testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py26,py27
+
+
+[testenv]
+deps = -r{toxinidir}/travis-requirements.txt
+commands = nosetests


### PR DESCRIPTION
The [tox](https://testrun.org/tox) testing tool automatizes the creation of testing environments for multiple interpreters, making it easier and faster to test dh-virtualenv, as it keeps compatibility back to python2.6.

This change adds a small `tox.ini` file that allows to run all tests for all environments with:

    tox

Tox can be easily installed via `pip`:

    pip install tox