### PR TITLE
Escape shebang lines with `re.escape` before passing to sed

### DIFF
--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -172,7 +172,7 @@ class Deployment(object):
         """
         pythonpath = os.path.join(self.virtualenv_install_dir, 'bin/python')
         for f in self.find_script_files():
-            regex = r's-^#!.*bin/\(env \)\?{names}-#!{pythonpath}-'\
+            regex = r's:^#!.*bin/\(env \)\?{names}:#!{pythonpath}:'\
                 .format(names=_PYTHON_INTERPRETERS_REGEX, pythonpath=pythonpath)
             subprocess.check_call(['sed', '-i', regex, f])
 

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -172,8 +172,8 @@ class Deployment(object):
         """
         pythonpath = os.path.join(self.virtualenv_install_dir, 'bin/python')
         for f in self.find_script_files():
-            regex = r's:^#!.*bin/\(env \)\?{names}:#!{pythonpath}:'\
-                .format(names=_PYTHON_INTERPRETERS_REGEX, pythonpath=pythonpath)
+            regex = r's-^#!.*bin/\(env \)\?{names}-#!{pythonpath}-'\
+                .format(names=_PYTHON_INTERPRETERS_REGEX, pythonpath=re.escape(pythonpath))
             subprocess.check_call(['sed', '-i', regex, f])
 
     def fix_activate_path(self):

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -85,6 +85,13 @@ def test_shebangs_fix_overridden_root():
             yield check_shebangs_fix, interpreter, 'foo/test'
 
 
+def test_shebangs_fix_special_chars_in_path():
+    """Generate a test for each possible interpreter while overriding root"""
+    with override_envvar('DH_VIRTUALENV_INSTALL_ROOT', 'some-directory:with/special_chars'):
+        for interpreter in ('python', 'pypy', 'ipy', 'jython'):
+            yield check_shebangs_fix, interpreter, 'some-directory:with/special_chars/test'
+
+
 def check_shebangs_fix(interpreter, path):
     """Checks shebang substitution for the given interpreter"""
     deployment = Deployment('test')

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -86,7 +86,7 @@ def test_shebangs_fix_overridden_root():
 
 
 def test_shebangs_fix_special_chars_in_path():
-    """Generate a test for each possible interpreter while overriding root"""
+    """Generate a test for each possible interpreter while overriding root to contain special characters"""
     with override_envvar('DH_VIRTUALENV_INSTALL_ROOT', 'some-directory:with/special_chars'):
         for interpreter in ('python', 'pypy', 'ipy', 'jython'):
             yield check_shebangs_fix, interpreter, 'some-directory:with/special_chars/test'

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -93,8 +93,8 @@ def test_shebangs_fix_special_chars_in_path():
     with override_envvar('DH_VIRTUALENV_INSTALL_ROOT',
                          'some-directory:with/special_chars'):
         for interpreter in ('python', 'pypy', 'ipy', 'jython'):
-            yield check_shebangs_fix, interpreter,
-            'some-directory:with/special_chars/test'
+            yield (check_shebangs_fix, interpreter,
+                   'some-directory:with/special_chars/test')
 
 
 def check_shebangs_fix(interpreter, path):

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -86,10 +86,15 @@ def test_shebangs_fix_overridden_root():
 
 
 def test_shebangs_fix_special_chars_in_path():
-    """Generate a test for each possible interpreter while overriding root to contain special characters"""
-    with override_envvar('DH_VIRTUALENV_INSTALL_ROOT', 'some-directory:with/special_chars'):
+    """
+    Generate a test for each possible interpreter
+    while overriding root to contain special characters
+    """
+    with override_envvar('DH_VIRTUALENV_INSTALL_ROOT',
+                         'some-directory:with/special_chars'):
         for interpreter in ('python', 'pypy', 'ipy', 'jython'):
-            yield check_shebangs_fix, interpreter, 'some-directory:with/special_chars/test'
+            yield check_shebangs_fix, interpreter,
+            'some-directory:with/special_chars/test'
 
 
 def check_shebangs_fix(interpreter, path):


### PR DESCRIPTION
Fixes #139 

I chose to change the delimiter to a colon since @jhermann pointed out it's less likely to conflict.