### PR TITLE
Introduce new --index-url to take over --pypi-url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # Build files
 build/
 dh_virtualenv.egg-info/
+.tox
 
 # Sphinx build
 doc/_build

--- a/dh_virtualenv/__init__.py
+++ b/dh_virtualenv/__init__.py
@@ -18,3 +18,6 @@
 # <http://www.gnu.org/licenses/>.
 
 from .deployment import Deployment
+
+# Make Flake8 happy
+assert Deployment

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -31,7 +31,7 @@ _PYTHON_INTERPRETERS_REGEX = r'\(' + r'\|'.join(PYTHON_INTERPRETERS) + r'\)'
 
 class Deployment(object):
     def __init__(self, package, extra_urls=[], preinstall=[],
-                 pypi_url=None, setuptools=False, python=None,
+                 index_url=None, setuptools=False, python=None,
                  builtin_venv=False, sourcedirectory=None, verbose=False,
                  extra_pip_arg=[], use_system_packages=False,
                  skip_install=False,
@@ -58,7 +58,7 @@ class Deployment(object):
         self.extra_urls = extra_urls
         self.preinstall = preinstall
         self.extra_pip_arg = extra_pip_arg
-        self.pypi_url = pypi_url
+        self.index_url = index_url
         self.log_file = tempfile.NamedTemporaryFile()
         self.verbose = verbose
         self.setuptools = setuptools
@@ -75,7 +75,7 @@ class Deployment(object):
         return cls(package,
                    extra_urls=options.extra_index_url,
                    preinstall=options.preinstall,
-                   pypi_url=options.pypi_url,
+                   index_url=options.index_url,
                    setuptools=options.setuptools,
                    python=options.python,
                    builtin_venv=options.builtin_venv,
@@ -126,8 +126,8 @@ class Deployment(object):
 
         self.pip_prefix.append('install')
 
-        if self.pypi_url:
-            self.pip_prefix.append('--pypi-url={0}'.format(self.pypi_url))
+        if self.index_url:
+            self.pip_prefix.append('--index-url={0}'.format(self.index_url))
         self.pip_prefix.extend([
             '--extra-index-url={0}'.format(url) for url in self.extra_urls
         ])

--- a/doc/info.rst
+++ b/doc/info.rst
@@ -24,6 +24,11 @@ In the sequence the ``dh_virtualenv`` is inserted right after
 Following list contains most notable changes by version. For full list
 consult the git history of the project.
 
+0.12 (unreleased)
+=================
+
+* Deprecate ``--pypi-url`` in favour of ``--index-url``
+
 0.11
 ====
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -98,7 +98,7 @@ few command line options:
    to parse ``setup.py``. This flag can be provided multiple times to
    pass multiple packages for pre-install.
 
-.. cmdoption:: --pypi-url <URL>
+.. cmdoption:: --index-url <URL>
 
    Base URL of the PyPI server. This flag can be used to pass in a
    custom URL to a PyPI mirror. It's useful if you for example have an
@@ -171,6 +171,11 @@ few command line options:
    -- typically, by the packages ``./debian/<packagename>.install``
    file, possibly into a directory structure unrelated to the location
    of the virtual environment.
+
+.. cmdoption:: --pypi-url <URL>
+
+   .. deprecated:: 0.12
+      Use :option:`--index-url` instead.
 
 
 Advanced usage

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -213,7 +213,7 @@ def test_create_venv_with_extra_urls(callmock):
 @patch('subprocess.check_call')
 def test_create_venv_with_custom_index_url(callmock):
     d = Deployment('test', extra_urls=['foo', 'bar'],
-                   pypi_url='http://example.com/simple')
+                   index_url='http://example.com/simple')
     d.create_virtualenv()
     eq_('debian/test/usr/share/python/test', d.package_dir)
     callmock.assert_called_with(['virtualenv', '--no-site-packages',
@@ -221,7 +221,7 @@ def test_create_venv_with_custom_index_url(callmock):
     eq_([PY_CMD,
          PIP_CMD,
          'install',
-         '--pypi-url=http://example.com/simple',
+         '--index-url=http://example.com/simple',
          '--extra-index-url=foo',
          '--extra-index-url=bar',
          '--log=' + os.path.abspath('foo')], d.pip_prefix)
@@ -382,7 +382,7 @@ def test_deployment_from_options():
         ])
         d = Deployment.from_options('foo', options)
         eq_(d.package, 'foo')
-        eq_(d.pypi_url, 'http://example.org')
+        eq_(d.index_url, 'http://example.org')
         eq_(d.extra_urls, ['http://example.com'])
 
 

--- a/travis-requirements.txt
+++ b/travis-requirements.txt
@@ -4,4 +4,4 @@ Pygments==1.6
 Sphinx==1.2
 docutils==0.11
 mock==1.0.1
-nose==1.3.0
+nose==1.3.7


### PR DESCRIPTION
pip (nowadays) uses `--index-url` instead of `--pypi-url`. This hopefully reduces confusion