### PR TITLE
Add a --extra-virtualenv-arg

### DIFF
--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -79,6 +79,10 @@ def get_default_parser():
                       help='Extra args for the pip binary.'
                       'You can use this flag multiple times to pass in'
                       ' parameters to pip.', default=[])
+    parser.add_option('--extra-virtualenv-arg', action='append',
+                      help='Extra args for the virtualenv binary.'
+                      'You can use this flag multiple times to pass in'
+                      ' parameters to the virtualenv binary.', default=[])
     parser.add_option('--pypi-url',
                       help=('!!DEPRECATED, use --index-url instead!! '
                             'Base URL of the PyPI server'),

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -42,6 +42,7 @@ class Deployment(object):
                  sourcedirectory=None,
                  verbose=False,
                  extra_pip_arg=[],
+                 extra_virtualenv_arg=[],
                  use_system_packages=False,
                  skip_install=False,
                  install_suffix=None,
@@ -68,6 +69,7 @@ class Deployment(object):
         self.preinstall = preinstall
         self.upgrade_pip = upgrade_pip
         self.extra_pip_arg = extra_pip_arg
+        self.extra_virtualenv_arg = extra_virtualenv_arg
         self.index_url = index_url
         self.log_file = tempfile.NamedTemporaryFile()
         self.verbose = verbose
@@ -93,6 +95,7 @@ class Deployment(object):
                    sourcedirectory=options.sourcedirectory,
                    verbose=verbose,
                    extra_pip_arg=options.extra_pip_arg,
+                   extra_virtualenv_arg=options.extra_virtualenv_arg,
                    use_system_packages=options.use_system_packages,
                    skip_install=options.skip_install,
                    install_suffix=options.install_suffix,
@@ -120,6 +123,10 @@ class Deployment(object):
 
             if self.python:
                 virtualenv.extend(('--python', self.python))
+
+            # Add in any user supplied pip args
+            if self.extra_virtualenv_arg:
+                virtualenv.extend(self.extra_virtualenv_arg)
 
         virtualenv.append(self.package_dir)
         subprocess.check_call(virtualenv)

--- a/doc/dh_virtualenv.1.rst
+++ b/doc/dh_virtualenv.1.rst
@@ -45,6 +45,7 @@ OPTIONS
 --preinstall=PACKAGE			Preinstall a PACKAGE before
 					running pip.
 --extra-pip-arg				Extra arg for the pip executable.
+--extra-virtualenv-arg      Extra arg for the virtualenv executable.
 --pypi-url				Base URL for PyPI server.
 --setuptools				Use setuptools instead of
 					distribute.

--- a/doc/dh_virtualenv.1.rst
+++ b/doc/dh_virtualenv.1.rst
@@ -40,15 +40,13 @@ OPTIONS
 
 -p PACKAGE, --package=PACKAGE		Act on the package named PACKAGE
 -N PACKAGE, --no-package=PACKAGE	Do not act on the specified PACKAGE
--v, --verbose				Turn on verbose mode.
---extra-index-url			Pass extra index URL to pip
---preinstall=PACKAGE			Preinstall a PACKAGE before
-					running pip.
---extra-pip-arg				Extra arg for the pip executable.
---extra-virtualenv-arg      Extra arg for the virtualenv executable.
---pypi-url				Base URL for PyPI server.
---setuptools				Use setuptools instead of
-					distribute.
+-v, --verbose				        Turn on verbose mode.
+--extra-index-url			        Pass extra index URL to pip
+--preinstall=PACKAGE			    Preinstall a PACKAGE before running pip.
+--extra-pip-arg				        Extra arg for the pip executable.
+--extra-virtualenv-arg              Extra arg for the virtualenv executable.
+--pypi-url				            Base URL for PyPI server.
+--setuptools				        Use setuptools instead of distribute.
 
 QUICK GUIDE FOR MAINTAINERS
 ===========================

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -121,6 +121,12 @@ few command line options:
    override_dh_virtualenv section of the debian/rules file will
    disable the generation of pyc files.
 
+.. cmdoption:: --extra-virtualenv-arg <VIRTUALENV ARG>
+
+   Extra parameters to pass to the virtualenv executable. This is useful if
+   you need to change the behaviour of virtualenv during the packaging process.
+   You can use this flag multiple times to pass in different virtualenv flags.
+
 .. cmdoption:: --requirements <REQUIREMENTS FILE>
 
    Use a different requirements file when installing. Some packages

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -230,6 +230,17 @@ def test_create_venv_with_extra_urls(callmock):
 
 @patch('tempfile.NamedTemporaryFile', FakeTemporaryFile)
 @patch('subprocess.check_call')
+def test_create_venv_with_extra_virtualenv(callmock):
+    d = Deployment('test', extra_virtualenv_arg=["--never-download"])
+    d.create_virtualenv()
+    eq_('debian/test/usr/share/python/test', d.package_dir)
+    callmock.assert_called_with(['virtualenv', '--no-site-packages',
+                                 '--never-download',
+                                 'debian/test/usr/share/python/test'])
+
+
+@patch('tempfile.NamedTemporaryFile', FakeTemporaryFile)
+@patch('subprocess.check_call')
 def test_create_venv_with_custom_index_url(callmock):
     d = Deployment('test', extra_urls=['foo', 'bar'],
                    index_url='http://example.com/simple')


### PR DESCRIPTION
Like --extra-pip-arg it's allow to pass argument to virtualenv not yet supported by dh_virtualenv

Our use case is we have trouble when building on Xenial without internet that's why we need to pass --no-download to virtualenv otherwise the virtualenv from Xenial download pip.

Adding this option allow us to experiment the virtualenv flags to fix the build.