### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ factor is that you have to run the same Python interpreter as the
 operating system.
 
 For complete online documentation, see
-[the documentation online](https://dh-virtualenv.readthedocs.org/en/latest/).
+[the documentation online](https://dh-virtualenv.readthedocs.io/en/latest/).
 
 ## Using dh-virtualenv
 

--- a/doc/dh_virtualenv.1.rst
+++ b/doc/dh_virtualenv.1.rst
@@ -66,7 +66,7 @@ SEE ALSO
 ========
 
 Online documentation can be found at
-http://dh-virtualenv.readthedocs.org/en/latest.
+https://dh-virtualenv.readthedocs.io/en/latest.
 
 This package should also ship with documentation under
 `/usr/share/doc/dh-virtualenv`.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.