### PR TITLE
Preparations to 1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ NOTE: Be aware that the configuration in debian/rules expects tabs instead of sp
 
 Once the package is built, you have a virtualenv contained in a Debian
 package and upon installation it gets placed, by default, under
-`/usr/share/python/<packagename>`.
+`/opt/venvs/<packagename>`.
 
 For more information and usage documentation, check the accompanying
 documentation in the `doc` folder.
@@ -65,7 +65,7 @@ In the sequence the dh_virtualenv is inserted right after dh_perl.
     $ nosetests ./test/test_deployment.py
 
 ## Code of conduct
-This project adheres to the [Open Code of Conduct][code-of-conduct]. 
+This project adheres to the [Open Code of Conduct][code-of-conduct].
 By participating, you are expected to honor this code.
 
 ## License

--- a/bin/dh_virtualenv
+++ b/bin/dh_virtualenv
@@ -54,7 +54,7 @@ def main():
     if 'nocheck' in os.environ.get('DEB_BUILD_OPTIONS', ''):
         do_test = False
     else:
-        do_test = options.test
+        do_test = options.setuptools_test
 
     # Older DebHelpers, like the one on Debian Squeeze, expect to be
     # passed the packages keyword argument. Newer (like Ubuntu

--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -40,19 +40,21 @@ class DebhelperOptionParser(OptionParser):
         return OptionParser.parse_args(self, args, values)
 
 
-def _check_index_url(option, opt_str, value, parser, *args, **kwargs):
-    if opt_str == '--pypi-url':
-        # Work around 2.7 hiding the DeprecationWarning
-        with warnings.catch_warnings():
-            warnings.simplefilter('default')
-            warnings.warn('Use of --pypi-url is deprecated. Use --index-url intead',
-                          DeprecationWarning)
-    if parser.values.index_url:
-        # We've already set the index_url, which means that we have both
-        # --index-url and --pypi-url passed in.
-        raise OptionValueError('Deprecated --pypi-url and the new '
-                               '--index-url are mutually exclusive')
-    parser.values.index_url = value
+def _check_for_depreacted_options(
+        option, opt_str, value, parser, *args, **kwargs):
+    if opt_str in ('--pypi-url', '--index-url'):
+        if opt_str == '--pypi-url':
+            # Work around 2.7 hiding the DeprecationWarning
+            with warnings.catch_warnings():
+                warnings.simplefilter('default')
+                warnings.warn('Use of --pypi-url is deprecated. Use --index-url instead',
+                              DeprecationWarning)
+        if parser.values.index_url:
+            # We've already set the index_url, which means that we have both
+            # --index-url and --pypi-url passed in.
+            raise OptionValueError('Deprecated --pypi-url and the new '
+                                   '--index-url are mutually exclusive')
+        parser.values.index_url = value
 
 
 def get_default_parser():
@@ -89,19 +91,12 @@ def get_default_parser():
                       help='Extra args for the virtualenv binary.'
                       'You can use this flag multiple times to pass in'
                       ' parameters to the virtualenv binary.', default=[])
-    parser.add_option('--pypi-url',
-                      help=('!!DEPRECATED, use --index-url instead!! '
-                            'Base URL of the PyPI server'),
-                      action='callback',
-                      dest='index_url',
-                      type='string',
-                      callback=_check_index_url)
     parser.add_option('--index-url',
                       help='Base URL of the PyPI server',
                       action='callback',
                       type='string',
                       dest='index_url',
-                      callback=_check_index_url)
+                      callback=_check_for_depreacted_options)
     parser.add_option('--python', help='The Python to use')
     parser.add_option('--builtin-venv', action='store_true',
                       help='Use the built-in venv module. Only works on '
@@ -144,4 +139,13 @@ def get_default_parser():
                       help=("Act on all architecture independent packages. "
                             "This option is ignored"),
                       action="store_true")
+
+    # Deprecated options
+    parser.add_option('--pypi-url',
+                      help=('!!DEPRECATED, use --index-url instead!! '
+                            'Base URL of the PyPI server'),
+                      action='callback',
+                      dest='index_url',
+                      type='string',
+                      callback=_check_for_depreacted_options)
     return parser

--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -63,7 +63,7 @@ def _check_for_deprecated_options(
         if opt_str == '--no-test':
             with warnings.catch_warnings():
                 warnings.simplefilter('default')
-                warnings.warn('Use of --no-test is deprecated and has now '
+                warnings.warn('Use of --no-test is deprecated and has no '
                               'effect. Use --setuptools-test if you want to '
                               'execute `setup.py test` during package build.',
                               DeprecationWarning)

--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -40,7 +40,7 @@ class DebhelperOptionParser(OptionParser):
         return OptionParser.parse_args(self, args, values)
 
 
-def _check_for_depreacted_options(
+def _check_for_deprecated_options(
         option, opt_str, value, parser, *args, **kwargs):
     # TODO: If more deprectaed options pop up, refactor this method to
     # handle them in more generic way (or actually remove the
@@ -113,7 +113,7 @@ def get_default_parser():
                       action='callback',
                       type='string',
                       dest='index_url',
-                      callback=_check_for_depreacted_options)
+                      callback=_check_for_deprecated_options)
     parser.add_option('--python', help='The Python to use')
     parser.add_option('--builtin-venv', action='store_true',
                       help='Use the built-in venv module. Only works on '
@@ -144,7 +144,7 @@ def get_default_parser():
                       default=False,
                       action='callback',
                       help='Run `setup.py test` when building the package',
-                      callback=_check_for_depreacted_options)
+                      callback=_check_for_deprecated_options)
 
     # Ignore user-specified option bundles
     parser.add_option('-O', help=SUPPRESS_HELP)
@@ -166,12 +166,12 @@ def get_default_parser():
                       action='callback',
                       dest='index_url',
                       type='string',
-                      callback=_check_for_depreacted_options)
+                      callback=_check_for_deprecated_options)
     parser.add_option('--no-test',
                       help="!!DEPRECATED, this command has no effect. "
                       "See --setuptools-test!! "
                       "Don't run tests for the package. Useful "
                       "for example when you have packaged with distutils.",
                       action='callback',
-                      callback=_check_for_depreacted_options)
+                      callback=_check_for_deprecated_options)
     return parser

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -24,7 +24,7 @@ import subprocess
 import tempfile
 
 ROOT_ENV_KEY = 'DH_VIRTUALENV_INSTALL_ROOT'
-DEFAULT_INSTALL_DIR = '/usr/share/python/'
+DEFAULT_INSTALL_DIR = '/opt/venvs/'
 PYTHON_INTERPRETERS = ['python', 'pypy', 'ipy', 'jython']
 _PYTHON_INTERPRETERS_REGEX = r'\(' + r'\|'.join(PYTHON_INTERPRETERS) + r'\)'
 

--- a/doc/dh_virtualenv.1.rst
+++ b/doc/dh_virtualenv.1.rst
@@ -51,7 +51,7 @@ OPTIONS
 --install-suffix=SUFFIX			Override virttualenv installation suffix
 --upgrage-pip				Force upgrade pip in virtualenv
 --requirements=FILE			Use FILE for requirements
---no-test				Skip tests
+--setuptools-test			Run `setup.py test` upon build.
 --python=PATH				Use Python interpreter at PATH
 --builtin-venv				Use built-in venv of Python 3
 --skip-install				Don't run ``pip install .``
@@ -69,5 +69,5 @@ SEE ALSO
 Online documentation can be found at
 https://dh-virtualenv.readthedocs.io/en/latest.
 
-This package should also ship with documentation under
+This package should also ship with the complete documentation under
 `/usr/share/doc/dh-virtualenv`.

--- a/doc/info.rst
+++ b/doc/info.rst
@@ -27,6 +27,12 @@ consult the git history of the project.
 1.0 (unreleased)
 =================
 
+* **Backwards incompatible** Change the default install root to
+  ``/opt/venvs``. This is due to the old installation root
+  (``/usr/share/python``) clashing with Debian provided Python
+  utilities. To maintain the old install location, use
+  :envvar:`DH_VIRTUALENV_INSTALL_ROOT` and point it to
+  ``/usr/share/python``.
 * **Backwards incompatible** By default, do not run `setup.py test`
   upon building. The :option:`--no-test` flag has no longer any effect. To
   get the old behaviour, use :option:`--setuptools-test` flag instead.
@@ -38,7 +44,7 @@ consult the git history of the project.
   to `Kris Kvilekval <https://github.com/kkvilekval>`_ for the
   implementation!
 * Buildsystem: Add support for custom requirements file location
-  using :envvar:`DH_REQUIREMENTS_FILE` and for custom :program:`pip` command
+  using :envvar:`DH_REQUIREMENTS_FILE` and for custom ``pip`` command
   line arguments using :envvar:`DH_PIP_EXTRA_ARGS`. Thanks to `Einar
   Forselv <https://github.com/einarf>`_ for implementing!
 * Fixing shebangs now supports multiple interpreters. Thanks `Javier

--- a/doc/info.rst
+++ b/doc/info.rst
@@ -24,7 +24,7 @@ In the sequence the ``dh_virtualenv`` is inserted right after
 Following list contains most notable changes by version. For full list
 consult the git history of the project.
 
-0.12 (unreleased)
+1.0 (unreleased)
 =================
 
 * Deprecate ``--pypi-url`` in favour of ``--index-url``

--- a/doc/info.rst
+++ b/doc/info.rst
@@ -34,8 +34,9 @@ consult the git history of the project.
   :envvar:`DH_VIRTUALENV_INSTALL_ROOT` and point it to
   ``/usr/share/python``.
 * **Backwards incompatible** By default, do not run `setup.py test`
-  upon building. The :option:`--no-test` flag has no longer any effect. To
-  get the old behaviour, use :option:`--setuptools-test` flag instead.
+  upon building. The :option:`--no-test` flag has no longer has any
+  effect. To get the old behaviour, use the
+  :option:`--setuptools-test` flag instead.
 * Deprecate :option:`--pypi-url` in favour of :option:`--index-url`
 * Support upgrading pip to the latest release with :option:`--upgrade-pip`
   flag.

--- a/doc/info.rst
+++ b/doc/info.rst
@@ -33,11 +33,12 @@ consult the git history of the project.
 * Deprecate :option:`--pypi-url` in favour of :option:`--index-url`
 * Support upgrading pip to the latest release with :option:`--upgrade-pip`
   flag.
-* Buildsystem: Add support for :envvar:`DH_UPGRADE_PIP` and
-  :envvar:`DH_UPGRADE_WHEEL`. Thanks to `Kris Kvilekval
-  <https://github.com/kkvilekval>`_ for the implementation!
+* Buildsystem: Add support for :envvar:`DH_UPGRADE_PIP`,
+  :envvar:`DH_UPGRADE_SETUPTOOLS` and :envvar:`DH_UPGRADE_WHEEL`. Thanks
+  to `Kris Kvilekval <https://github.com/kkvilekval>`_ for the
+  implementation!
 * Buildsystem: Add support for custom requirements file location
-  using :envvar:`DH_REQUIREMENTS_FILE` and for custom `pip` command
+  using :envvar:`DH_REQUIREMENTS_FILE` and for custom :program:`pip` command
   line arguments using :envvar:`DH_PIP_EXTRA_ARGS`. Thanks to `Einar
   Forselv <https://github.com/einarf>`_ for implementing!
 * Fixing shebangs now supports multiple interpreters. Thanks `Javier
@@ -47,7 +48,7 @@ consult the git history of the project.
 ====
 
 * Allow passing explicit filename for `requirements.txt` using
-  `--requirements` option. Thanks to `Eric Larson
+  :option:`--requirements` option. Thanks to `Eric Larson
   <https://github.com/ionrock>`_ for implementing!
 * Ensure that venv is configured before starting any daemons. Thanks
   to `Chris Lamb <https://github.com/lamby>`_ for fixing this!
@@ -60,32 +61,31 @@ consult the git history of the project.
 
 * **Backwards incompatible** Fix installation using the built-in
   virtual environment on 3.4. This might break installation on Python
-  versions prior to 3.4 when using `--builtin-venv` flag. Thanks to
-  `Elonen <https://github.com/elonen>`_ for fixing!
-* Honor ``DH_VIRTUALENV_INSTALL_ROOT`` in build system. Thanks to
+  versions prior to 3.4 when using :option:`--builtin-venv` flag.
+  Thanks to `Elonen <https://github.com/elonen>`_ for fixing!
+* Honor :envvar:`DH_VIRTUALENV_INSTALL_ROOT` in build system. Thanks to
   `Ludwig Hähne <https://github.com/Pankrat>`_ for implementing!
 * Allow overriding virtualenv arguments by using the
-  ``DH_VIRTUALENV_ARGUMENTS`` environment variable when using the
+  :envvar:`DH_VIRTUALENV_ARGUMENTS` environment variable when using the
   build system. Thanks to `Ludwig Hähne <https://github.com/Pankrat>`_
   for implementing!
 * Add option to skip installation of the actual project. In other
-  words using ``--skip-install`` installs only the dependencies of the
-  project found in requirements.txt. Thanks to `Phillip
+  words using :option:`--skip-install` installs only the dependencies
+  of the project found in requirements.txt. Thanks to `Phillip
   O'Donnell <https://github.com/phillipod>`_ for implementing!
 * Support custom installation suffix instead of the package name via
-  ``--install-suffix``. Thanks to `Phillip
-  O'Donnell <https://github.com/phillipod>`_ for implementing!
-
+  :option:`--install-suffix`. Thanks to `Phillip O'Donnell
+  <https://github.com/phillipod>`_ for implementing!
 
 0.9
 ===
 
 * Support using system packages via a command line flag
-  ``--use-system-packages``. Thanks to `Wes Mason
+  :option:`--use-system-packages`. Thanks to `Wes Mason
   <https://github.com/1stvamp>`_ for implementing this feature!
 * Introduce a new, experimental, more modular build system. See the
   :doc:`usage` for documentation.
-* Respect the ``DEB_NO_CHECK`` environment variable.
+* Respect the :envvar:`DEB_NO_CHECK` environment variable.
 
 0.8
 ===
@@ -93,13 +93,13 @@ consult the git history of the project.
 * Support for running triggers upon host interpreter update. This new
   feature makes it possible to upgrade the host Python interpreter
   and avoid breakage of all the virtualenvs installed with
-  virtualenv. For usage, see the the :doc:`tutorial`. Huge thanks to
+  dh-virtualenv. For usage, see the the :doc:`tutorial`. Huge thanks to
   `Jürgen Hermann <https://github.com/jhermann>`_ for implementing
   this long wanted feature!
 * Add support for the built-in ``venv`` module. Thanks to `Petri
   Lehtinen <https://github.com/akheron>`_!
 * Allow custom ``pip`` flags to be passed via the
-  ``--extra-pip-args`` flag. Thanks to `@labeneator
+  :option:`--extra-pip-arg` flag. Thanks to `@labeneator
   <https://github.com/labeneator>`_ for the feature.
 
 0.7
@@ -107,10 +107,10 @@ consult the git history of the project.
 
 * **Backwards incompatible** Support running tests. This change
   breaks builds that use distutils. For those cases a flag
-  ``--no-test`` needs to be passed.
+  :option:`--no-test` needs to be passed.
 * Add tutorial to documentation
-* Don't crash on debbuild parameters ``-i`` and ``-a``
-* Support custom source directory (debhelper's flag ``-D``)
+* Don't crash on debbuild parameters :option:`-i` and :option:`-a`
+* Support custom source directory (debhelper's flag :option:`-D`)
 
 0.6
 ===

--- a/doc/info.rst
+++ b/doc/info.rst
@@ -27,9 +27,21 @@ consult the git history of the project.
 1.0 (unreleased)
 =================
 
-* Deprecate ``--pypi-url`` in favour of ``--index-url``
-* Support upgrading pip to the latest release with ``--upgrade-pip``
+* **Backwards incompatible** By default, do not run `setup.py test`
+  upon building. The :option:`--no-test` flag has no longer any effect. To
+  get the old behaviour, use :option:`--setuptools-test` flag instead.
+* Deprecate :option:`--pypi-url` in favour of :option:`--index-url`
+* Support upgrading pip to the latest release with :option:`--upgrade-pip`
   flag.
+* Buildsystem: Add support for :envvar:`DH_UPGRADE_PIP` and
+  :envvar:`DH_UPGRADE_WHEEL`. Thanks to `Kris Kvilekval
+  <https://github.com/kkvilekval>`_ for the implementation!
+* Buildsystem: Add support for custom requirements file location
+  using :envvar:`DH_REQUIREMENTS_FILE` and for custom `pip` command
+  line arguments using :envvar:`DH_PIP_EXTRA_ARGS`. Thanks to `Einar
+  Forselv <https://github.com/einarf>`_ for implementing!
+* Fixing shebangs now supports multiple interpreters. Thanks `Javier
+  Santacruz <https://github.com/jvrsantacruz>`_!
 
 0.11
 ====

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -7,7 +7,7 @@ with but it also supports lot of customization to fit in your general
 needs.
 
 By default, *dh-virtualenv* installs your packages under
-``/usr/share/python/<packagename>``. The package name is provided by
+``/opt/venvs/<packagename>``. The package name is provided by
 the ``debian/control`` file.
 
 To use an alternative install prefix, add a line like
@@ -17,7 +17,7 @@ To use an alternative install prefix, add a line like
   export DH_VIRTUALENV_INSTALL_ROOT=</your/custom/install/dir>
 
 to the top of your ``debian/rules`` file. dh_virtualenv will use
-:envvar:`DH_VIRTUALENV_INSTALL_ROOT` instead of ``/usr/share/python``
+:envvar:`DH_VIRTUALENV_INSTALL_ROOT` instead of ``/opt/venvs``
 when it constructs the install path.
 
 To use an install suffix other than the package name, call the
@@ -92,7 +92,7 @@ few command line options:
 .. cmdoption:: --install-suffix <suffix>
 
    Override virtualenv installation suffix. The suffix is appended to
-   ``/usr/share/python``, or the :envvar:`DH_VIRTUALENV_INSTALL_ROOT`
+   ``/opt/venvs``, or the :envvar:`DH_VIRTUALENV_INSTALL_ROOT`
    environment variable if specified, to construct the installation
    path.
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -106,9 +106,9 @@ few command line options:
    in the virtualenv's bin/ directory.
 
 .. cmdoption:: --upgrade-pip <package>
-
-   Force upgrading pip to the latest available release. *Note:* This
-   can produce non-repeatable builds.
+   .. versionadded:: 1.0
+      Force upgrading pip to the latest available release. *Note:* This
+      can produce non-repeatable builds.
 
 .. cmdoption:: --index-url <URL>
 
@@ -148,12 +148,6 @@ few command line options:
 
    Use setuptools instead of distribute in the virtualenv
 
-.. cmdoption:: --no-test
-
-   Skip running ``python setup.py test`` after dependencies and the
-   package is installed. This is useful if the Python code is packaged
-   using distutils and not setuptools.
-
 .. cmdoption:: --python <path>
 
    Use a specific Python interpreter found in ``path`` as the
@@ -192,8 +186,13 @@ few command line options:
 
 .. cmdoption:: --pypi-url <URL>
 
-   .. deprecated:: 0.12
+   .. deprecated:: 1.0
       Use :option:`--index-url` instead.
+
+.. cmdoption:: --no-test
+
+   .. deprecated:: 1.0
+      This option has no effect. See :option:`--setuptools-test`.
 
 
 Advanced usage

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -21,9 +21,9 @@ to the top of your ``debian/rules`` file. dh_virtualenv will use
 when it constructs the install path.
 
 To use an install suffix other than the package name, call the
-``dh_virtualenv`` command using with the :option:`--install-suffix`
-command line option. See Advanced Usage for further information
-on passing options.
+``dh_virtualenv`` command using the :option:`--install-suffix` command
+line option. See Advanced Usage for further information on passing
+options.
 
 Simple usecase
 ==============
@@ -54,10 +54,10 @@ However, the tool makes a few assumptions of your project's structure:
 After these are place, you can just build the package with your
 favorite tool!
 
-Environmental variables
-=======================
+Environment variables
+=====================
 
-Certain environmental variables can be used to customise the behaviour
+Certain environment variables can be used to customise the behaviour
 of the debhelper sequencer in addition to the standard debhelper
 variables.
 
@@ -168,9 +168,9 @@ few command line options:
 
    .. versionadded:: 1.0
 
-   Force running ``python setup.py test`` when building the package.
-   This was the old default behaviour before version 1.0. This option
-   is incompatible with the deprecated :option:`--no-test`.
+   Run ``python setup.py test`` when building the package. This was
+   the old default behaviour before version 1.0. This option is
+   incompatible with the deprecated :option:`--no-test`.
 
 .. cmdoption:: --python <path>
 
@@ -281,7 +281,7 @@ possible to use ``debian/install`` files to include built files into
 the Debian package. This is not possible with the sequencer addition.
 
 The build system honors the :envvar:`DH_VIRTUALENV_INSTALL_ROOT`
-environment variable. Following other environmental variables can be
+environment variable. Following other environment variables can be
 used to customise the functionality:
 
 .. envvar:: DH_VIRTUALENV_ARGUMENTS

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -17,11 +17,11 @@ To use an alternative install prefix, add a line like
   export DH_VIRTUALENV_INSTALL_ROOT=</your/custom/install/dir>
 
 to the top of your ``debian/rules`` file. dh_virtualenv will use
-DH_VIRTUALENV_INSTALL_ROOT instead of ``/usr/share/python`` when it
-constructs the install path.
+:envvar:`DH_VIRTUALENV_INSTALL_ROOT` instead of ``/usr/share/python``
+when it constructs the install path.
 
 To use an install suffix other than the package name, call the
-``dh_virtualenv`` command using with the ``--install-suffix``
+``dh_virtualenv`` command using with the :option:`--install-suffix`
 command line option. See Advanced Usage for further information
 on passing options.
 
@@ -54,6 +54,20 @@ However, the tool makes a few assumptions of your project's structure:
 After these are place, you can just build the package with your
 favorite tool!
 
+Environmental variables
+=======================
+
+Certain environmental variables can be used to customise the behaviour
+of the debhelper sequencer in addition to the standard debhelper
+variables.
+
+.. envvar:: DH_VIRTUALENV_INSTALL_ROOT
+
+   Define a custom root location to install your package(s). The
+   resulting location for a specific package will be
+   ``/path/to/install/root/<packagename>` unless
+   :option:`--install-suffix` is used.
+
 Command line options
 ====================
 
@@ -78,7 +92,7 @@ few command line options:
 .. cmdoption:: --install-suffix <suffix>
 
    Override virtualenv installation suffix. The suffix is appended to
-   ``/usr/share/python``, or the ``DH_VIRTUALENV_INSTALL_ROOT``
+   ``/usr/share/python``, or the :envvar:`DH_VIRTUALENV_INSTALL_ROOT`
    environment variable if specified, to construct the installation
    path.
 
@@ -106,9 +120,11 @@ few command line options:
    in the virtualenv's bin/ directory.
 
 .. cmdoption:: --upgrade-pip <package>
+
    .. versionadded:: 1.0
-      Force upgrading pip to the latest available release. *Note:* This
-      can produce non-repeatable builds.
+
+   Force upgrading pip to the latest available release. *Note:* This
+   can produce non-repeatable builds.
 
 .. cmdoption:: --index-url <URL>
 
@@ -124,7 +140,7 @@ few command line options:
    Extra parameters to pass to the pip executable. This is useful if
    you need to change the behaviour of pip during the packaging process.
    You can use this flag multiple times to pass in different pip flags.
-   As an example passing in --extra-pip-arg "--no-compile" to the
+   As an example passing in :option:`--extra-pip-arg` "--no-compile" to the
    override_dh_virtualenv section of the debian/rules file will
    disable the generation of pyc files.
 
@@ -148,6 +164,14 @@ few command line options:
 
    Use setuptools instead of distribute in the virtualenv
 
+.. cmdoption:: --setuptools-test
+
+   .. versionadded:: 1.0
+
+   Force running ``python setup.py test`` when building the package.
+   This was the old default behaviour before version 1.0. This option
+   is incompatible with the deprecated :option:`--no-test`.
+
 .. cmdoption:: --python <path>
 
    Use a specific Python interpreter found in ``path`` as the
@@ -158,10 +182,10 @@ few command line options:
 
    Enable the use of the build-in ``venv`` module, i.e. use ``python
    -m venv`` to create the virtualenv. For this to work, requires
-   Python 3.4 or later to be used, e.g. by using the option ``--python
-   /usr/bin/python3.4``. (Python 3.3 has the ``venv`` module, but
-   virtualenvs created with Python 3.3 are not bootstrapped with
-   setuptools or pip.)
+   Python 3.4 or later to be used, e.g. by using the option
+   :option:`--python` ``/usr/bin/python3.4``. (Python 3.3 has the
+   ``venv`` module, but virtualenvs created with Python 3.3 are not
+   bootstrapped with setuptools or pip.)
 
 .. cmdoption:: -S, --use-system-packages
 
@@ -256,44 +280,62 @@ In addition the separation of build and install steps makes it
 possible to use ``debian/install`` files to include built files into
 the Debian package. This is not possible with the sequencer addition.
 
-The build system honors the ``DH_VIRTUALENV_INSTALL_ROOT`` environment
-variable. Arguments can be passed to virtualenv by setting
-``DH_VIRTUALENV_ARGUMENTS``. For example:
+The build system honors the :envvar:`DH_VIRTUALENV_INSTALL_ROOT`
+environment variable. Following other environmental variables can be
+used to customise the functionality:
 
-.. code-block:: make
+.. envvar:: DH_VIRTUALENV_ARGUMENTS
 
-  export DH_VIRTUALENV_ARGUMENTS=--no-site-packages --always-copy
+   Pass given extra arguments to the ``virtualenv`` command
 
-The default is to create the virtual environment with ``--no-site-packages``.
+   For example:
 
-Overriding the requirements file can be done with the ``DH_REQUIREMENTS_FILE`` environment
-variable. For example:
+   .. code-block:: make
 
-.. code-block:: make
+      export DH_VIRTUALENV_ARGUMENTS="--no-site-packages --always-copy"
 
-  export DH_REQUIREMENTS_FILE="requirements-deploy.txt"
-
-
-Upgrade pip  by setting ``DH_UPGRADE_PIP`` to empty (latest version) or  specific version. For example:
-
-.. code-block::make
-  export DH_UPGRADE_PIP=8.1.2
+   The default is to create the virtual environment with
+   :option:`--no-site-packages`.
 
 
-Upgrade setuptools  by setting ``DH_UPGRADE_SETUPTOOLS`` to empty (latest version) or  specific version. For example:
+.. envvar:: DH_REQUIREMENTS_FILE
 
-.. code-block::make
-  export DH_UPGRADE_SETUPTOOLS=
+   .. versionadded:: 1.0
 
-Upgrade wheel  by setting ``DH_UPGRADE_WHEEL`` to empty (latest version) or  specific version. For example:
+   Override the location of requirements file. See :option:`--requirements`.
 
-.. code-block::make
-  export DH_UPGRADE_WHEEL=
+.. envvar:: DH_UPGRADE_PIP
 
+   .. versionadded:: 1.0
 
-Additional parameters to ``pip`` can be defined in the ``DH_PIP_EXTRA_ARGS`` environment
-variable. For example:
+   Force upgrade of the ``pip`` tool by setting
+   :envvar:`DH_UPGRADE_PIP` to empty (latest version) or specific
+   version. For example:
 
-.. code-block:: make
+   .. code-block::make
+      export DH_UPGRADE_PIP=8.1.2
 
-  export DH_PIP_EXTRA_ARGS="--no-index --find-links=./requirements/wheels"
+.. envvar:: DH_UPGRADE_SETUPTOOLS
+
+   .. versionadded:: 1.0
+
+   Force upgrade of setuptools by setting
+   :envvar:`DH_UPGRADE_SETUPTOOLS` to empty (latest version) or
+   specific version.
+
+.. envvar:: DH_UPGRADE_WHEEL
+
+   .. versionadded:: 1.0
+
+   Force upgrade of wheel by setting ``DH_UPGRADE_WHEEL`` to empty
+   (latest version) or specific version.
+
+.. envvar:: DH_PIP_EXTRA_ARGS
+
+   .. versionadded:: 1.0
+
+   Pass additional parameters to the ``pip`` command. For example:
+
+   .. code-block:: make
+
+      export DH_PIP_EXTRA_ARGS="--no-index --find-links=./requirements/wheels"

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -71,7 +71,7 @@ def test_pypi_url_creates_deprecation_warning():
         ])
     eq_(len(w), 1)
     ok_(issubclass(w[-1].category, DeprecationWarning))
-    eq_(str(w[-1].message), 'Use of --pypi-url is deprecated. Use --index-url intead')
+    eq_(str(w[-1].message), 'Use of --pypi-url is deprecated. Use --index-url instead')
 
 
 @patch('sys.exit')
@@ -82,6 +82,20 @@ def test_pypi_url_index_url_conflict(exit_):
         parser.parse_args([
             '--pypi-url=http://example.com',
             '--index-url=http://example.org']
+        )
+    ok_('Deprecated --pypi-url and the new --index-url are mutually exclusive'
+        in f.getvalue())
+    exit_.assert_called_once_with(2)
+
+
+@patch('sys.exit')
+def test_pypi_url_index_url_conflict_independent_from_order(exit_):
+    parser = cmdline.get_default_parser()
+    f = StringIO()
+    with patch('sys.stderr', f):
+        parser.parse_args([
+            '--index-url=http://example.org',
+            '--pypi-url=http://example.com']
         )
     ok_('Deprecated --pypi-url and the new --index-url are mutually exclusive'
         in f.getvalue())

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -83,7 +83,7 @@ def test_no_test_creates_deprecation_warning():
     eq_(len(w), 1)
     ok_(issubclass(w[0].category, DeprecationWarning))
     eq_(str(w[0].message),
-        'Use of --no-test is deprecated and has now effect. '
+        'Use of --no-test is deprecated and has no effect. '
         'Use --setuptools-test if you want to execute '
         '`setup.py test` during package build.')
 

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -31,13 +31,17 @@ from dh_virtualenv import Deployment
 from dh_virtualenv.cmdline import get_default_parser
 
 
+PY_CMD = os.path.abspath('debian/test/opt/venvs/test/bin/python')
+PIP_CMD = os.path.abspath('debian/test/opt/venvs/test/bin/pip')
+
+
 class FakeTemporaryFile(object):
     name = 'foo'
 
 
 def _test_bin(name):
     return os.path.abspath(os.path.join(
-        'debian/test/usr/share/python/test/bin', name,
+        'debian/test/opt/venvs/test/bin', name,
     ))
 
 
@@ -65,7 +69,7 @@ def temporary_dir(fn):
 def test_shebangs_fix():
     """Generate a test for each possible interpreter"""
     for interpreter in ('python', 'pypy', 'ipy', 'jython'):
-        yield check_shebangs_fix, interpreter, '/usr/share/python/test'
+        yield check_shebangs_fix, interpreter, '/opt/venvs/test'
 
 
 def test_shebangs_fix_overridden_root():
@@ -216,11 +220,9 @@ def test_custom_pip_tool_used_for_installation(callmock, _):
 def test_create_venv(callmock):
     d = Deployment('test')
     d.create_virtualenv()
-    eq_('debian/test/usr/share/python/test', d.package_dir)
+    eq_('debian/test/opt/venvs/test', d.package_dir)
     callmock.assert_called_with(['virtualenv', '--no-site-packages',
-                                 'debian/test/usr/share/python/test'])
-    eq_([PY_CMD, PIP_CMD], d.pip_prefix)
-    eq_(['install', LOG_ARG], d.pip_args)
+                                 'debian/test/opt/venvs/test'])
 
 
 @patch('tempfile.NamedTemporaryFile', FakeTemporaryFile)
@@ -228,12 +230,10 @@ def test_create_venv(callmock):
 def test_create_venv_with_verbose(callmock):
     d = Deployment('test', verbose=True)
     d.create_virtualenv()
-    eq_('debian/test/usr/share/python/test', d.package_dir)
+    eq_('debian/test/opt/venvs/test', d.package_dir)
     callmock.assert_called_with(['virtualenv', '--no-site-packages',
                                  '--verbose',
-                                 'debian/test/usr/share/python/test'])
-    eq_([PY_CMD, PIP_CMD], d.pip_prefix)
-    eq_(['install', '-v', LOG_ARG], d.pip_args)
+                                 'debian/test/opt/venvs/test'])
 
 
 @patch('tempfile.NamedTemporaryFile', FakeTemporaryFile)
@@ -241,9 +241,9 @@ def test_create_venv_with_verbose(callmock):
 def test_create_venv_with_extra_urls(callmock):
     d = Deployment('test', extra_urls=['foo', 'bar'])
     d.create_virtualenv()
-    eq_('debian/test/usr/share/python/test', d.package_dir)
+    eq_('debian/test/opt/venvs/test', d.package_dir)
     callmock.assert_called_with(['virtualenv', '--no-site-packages',
-                                 'debian/test/usr/share/python/test'])
+                                 'debian/test/opt/venvs/test'])
     eq_([PY_CMD, PIP_CMD], d.pip_prefix)
     eq_(['install', '--extra-index-url=foo',
          '--extra-index-url=bar',
@@ -255,10 +255,10 @@ def test_create_venv_with_extra_urls(callmock):
 def test_create_venv_with_extra_virtualenv(callmock):
     d = Deployment('test', extra_virtualenv_arg=["--never-download"])
     d.create_virtualenv()
-    eq_('debian/test/usr/share/python/test', d.package_dir)
+    eq_('debian/test/opt/venvs/test', d.package_dir)
     callmock.assert_called_with(['virtualenv', '--no-site-packages',
                                  '--never-download',
-                                 'debian/test/usr/share/python/test'])
+                                 'debian/test/opt/venvs/test'])
 
 
 @patch('tempfile.NamedTemporaryFile', FakeTemporaryFile)
@@ -267,9 +267,9 @@ def test_create_venv_with_custom_index_url(callmock):
     d = Deployment('test', extra_urls=['foo', 'bar'],
                    index_url='http://example.com/simple')
     d.create_virtualenv()
-    eq_('debian/test/usr/share/python/test', d.package_dir)
+    eq_('debian/test/opt/venvs/test', d.package_dir)
     callmock.assert_called_with(['virtualenv', '--no-site-packages',
-                                 'debian/test/usr/share/python/test'])
+                                 'debian/test/opt/venvs/test'])
     eq_([PY_CMD, PIP_CMD], d.pip_prefix)
     eq_(['install',
          '--index-url=http://example.com/simple',
@@ -284,9 +284,9 @@ def test_create_venv_with_extra_pip_arg(callmock):
     d = Deployment('test', extra_pip_arg=['--no-compile'])
     d.create_virtualenv()
     d.install_dependencies()
-    eq_('debian/test/usr/share/python/test', d.package_dir)
+    eq_('debian/test/opt/venvs/test', d.package_dir)
     callmock.assert_called_with(['virtualenv', '--no-site-packages',
-                                 'debian/test/usr/share/python/test'])
+                                 'debian/test/opt/venvs/test'])
     eq_([PY_CMD, PIP_CMD], d.pip_prefix)
     eq_(['install', LOG_ARG, '--no-compile'], d.pip_args)
 
@@ -296,10 +296,10 @@ def test_create_venv_with_extra_pip_arg(callmock):
 def test_create_venv_with_setuptools(callmock):
     d = Deployment('test', setuptools=True)
     d.create_virtualenv()
-    eq_('debian/test/usr/share/python/test', d.package_dir)
+    eq_('debian/test/opt/venvs/test', d.package_dir)
     callmock.assert_called_with(['virtualenv', '--no-site-packages',
                                  '--setuptools',
-                                 'debian/test/usr/share/python/test'])
+                                 'debian/test/opt/venvs/test'])
     eq_([PY_CMD, PIP_CMD], d.pip_prefix)
     eq_(['install', LOG_ARG], d.pip_args)
 
@@ -309,9 +309,9 @@ def test_create_venv_with_setuptools(callmock):
 def test_create_venv_with_system_packages(callmock):
     d = Deployment('test', use_system_packages=True)
     d.create_virtualenv()
-    eq_('debian/test/usr/share/python/test', d.package_dir)
+    eq_('debian/test/opt/venvs/test', d.package_dir)
     callmock.assert_called_with(['virtualenv', '--system-site-packages',
-                                 'debian/test/usr/share/python/test'])
+                                 'debian/test/opt/venvs/test'])
     eq_([PY_CMD, PIP_CMD], d.pip_prefix)
     eq_(['install', LOG_ARG], d.pip_args)
 
@@ -321,10 +321,10 @@ def test_create_venv_with_system_packages(callmock):
 def test_venv_with_custom_python(callmock):
     d = Deployment('test', python='/tmp/python')
     d.create_virtualenv()
-    eq_('debian/test/usr/share/python/test', d.package_dir)
+    eq_('debian/test/opt/venvs/test', d.package_dir)
     callmock.assert_called_with(['virtualenv', '--no-site-packages',
                                  '--python', '/tmp/python',
-                                 'debian/test/usr/share/python/test'])
+                                 'debian/test/opt/venvs/test'])
     eq_([PY_CMD, PIP_CMD], d.pip_prefix)
     eq_(['install', LOG_ARG], d.pip_args)
 
@@ -358,7 +358,7 @@ def test_fix_activate_path():
     expected = textwrap.dedent("""
         other things
 
-        VIRTUAL_ENV="/usr/share/python/test"
+        VIRTUAL_ENV="/opt/venvs/test"
 
         more other things
     """)


### PR DESCRIPTION
Sorry for a huge PR, try reviewing comment by comment if possible.

This PR does three major things:

1. Tests are no longer run by default
2. Default installation path is changed
3. Next version will be tagged as 1.0 (YAY!)