### PR TITLE
Use patch.dict to avoid test pollution

### DIFF
--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -43,11 +43,10 @@ def test_test_debhelper_option_parsing():
 
 
 def test_parser_picks_up_DH_OPTIONS_from_environ():
-    os.environ['DH_OPTIONS'] = '--sourcedirectory=/tmp/'
-    parser = cmdline.get_default_parser()
-    opts, args = parser.parse_args()
-    eq_('/tmp/', opts.sourcedirectory)
-    del os.environ['DH_OPTIONS']
+    with patch.dict(os.environ, {'DH_OPTIONS': '--sourcedirectory=/tmp/'}):
+        parser = cmdline.get_default_parser()
+        opts, args = parser.parse_args()
+        eq_('/tmp/', opts.sourcedirectory)
 
 
 def test_get_default_parser():

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -54,24 +54,6 @@ def temporary_dir(fn):
     return _inner
 
 
-@contextlib.contextmanager
-def override_envvar(name, value):
-    """Set environment variable only during the test"""
-    def set_or_unset_envvar(name, value):
-        """Sets name to value. Unset name when value is None"""
-        if value is None:
-            del os.environ[name]
-        else:
-            os.environ[name] = value
-
-    previous = os.getenv(name)
-    set_or_unset_envvar(name, value)
-    try:
-        yield
-    finally:
-        set_or_unset_envvar(name, previous)
-
-
 def test_shebangs_fix():
     """Generate a test for each possible interpreter"""
     for interpreter in ('python', 'pypy', 'ipy', 'jython'):
@@ -80,7 +62,7 @@ def test_shebangs_fix():
 
 def test_shebangs_fix_overridden_root():
     """Generate a test for each possible interpreter while overriding root"""
-    with override_envvar('DH_VIRTUALENV_INSTALL_ROOT', 'foo'):
+    with patch.dict(os.environ, {'DH_VIRTUALENV_INSTALL_ROOT': 'foo'}):
         for interpreter in ('python', 'pypy', 'ipy', 'jython'):
             yield check_shebangs_fix, interpreter, 'foo/test'
 
@@ -90,8 +72,9 @@ def test_shebangs_fix_special_chars_in_path():
     Generate a test for each possible interpreter
     while overriding root to contain special characters
     """
-    with override_envvar('DH_VIRTUALENV_INSTALL_ROOT',
-                         'some-directory:with/special_chars'):
+    with patch.dict(
+        os.environ,
+        {'DH_VIRTUALENV_INSTALL_ROOT': 'some-directory:with/special_chars'}):
         for interpreter in ('python', 'pypy', 'ipy', 'jython'):
             yield (check_shebangs_fix, interpreter,
                    'some-directory:with/special_chars/test')


### PR DESCRIPTION
Pretty minor patch, just trying to get familiar with the codebase :)

There isn't an actual problem here, but if the `eq_` assertion had failed, the environment unpatching wouldn't happen.  the `patch.dict` contextmanager ensures it'll get unpatched even in exceptional cases.