### PR TITLE
buildsystem: allows to specify a virtualenv name

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -297,6 +297,14 @@ used to customise the functionality:
    The default is to create the virtual environment with
    :option:`--no-site-packages`.
 
+.. envvar:: DH_VIRTUALENV_INSTALL_SUFFIX
+
+   Override the default virtualenv name, instead of source package name.
+
+   For example:
+
+   .. code-block::make
+      export DH_VIRTUALENV_INSTALL_SUFFIX=venv
 
 .. envvar:: DH_REQUIREMENTS_FILE
 

--- a/lib/Debian/Debhelper/Buildsystem/dh_virtualenv.pm
+++ b/lib/Debian/Debhelper/Buildsystem/dh_virtualenv.pm
@@ -38,9 +38,9 @@ sub get_install_root {
 sub get_venv_builddir {
     my $this = shift;
     my $builddir = $this->get_builddir();
-    my $sourcepackage = $this->sourcepackage();
+    my $virtualenv_name = $ENV{DH_VIRTUALENV_INSTALL_SUFFIX} || $this->sourcepackage();
     my $prefix = $this->get_install_root();
-    return "$builddir$prefix/$sourcepackage";
+    return "$builddir$prefix/$virtualenv_name";
 }
 
 sub get_exec {

--- a/lib/Debian/Debhelper/Buildsystem/dh_virtualenv.pm
+++ b/lib/Debian/Debhelper/Buildsystem/dh_virtualenv.pm
@@ -145,7 +145,13 @@ sub install {
     $this->doit_in_builddir('mkdir', '-p', $destdir);
     $this->doit_in_builddir('cp', '-r', '-T', '.', $destdir);
 
-    my $new_python = "$prefix/$sourcepackage/bin/python";
+    my $new_python = undef;
+    if (defined $ENV{DH_VIRTUALENV_INSTALL_SUFFIX}) {
+        $new_python = "$prefix/" . $ENV{DH_VIRTUALENV_INSTALL_SUFFIX} . "/bin/python";
+
+    } else {
+        $new_python = "$prefix/$sourcepackage/bin/python";
+    }
 
     # Fix shebangs so that we use the Python in the final location
     # instead of the Python in the build directory


### PR DESCRIPTION
The dh_virtualenv target allows to specify a virtualenv name.
this commits introduce a `DH_VIRTUALENV_NAME` vars.