### PR TITLE
Ignore --extra-pip-arg in call for --upgrade-pip (fixes #197)

### DIFF
--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -96,6 +96,8 @@ class Deployment(object):
             '--extra-index-url={0}'.format(url) for url in extra_urls
         ])
         self.pip_args.append('--log={0}'.format(os.path.abspath(self.log_file.name)))
+        # Keep a copy with well-suported options only (for upgrading pip itself)
+        self.pip_upgrade_args = self.pip_args[:]
         # Add in any user supplied pip args
         self.pip_args.extend(extra_pip_arg)
 
@@ -165,7 +167,8 @@ class Deployment(object):
         # along lines of setuptools), but that does not get installed
         # by default virtualenv.
         if self.upgrade_pip:
-            subprocess.check_call(self.pip_preinstall('-U', 'pip'))
+            # First, bootstrap pip with a reduced option set (well-supported options)
+            subprocess.check_call(self.pip_preinstall_prefix + self.pip_upgrade_args + ['-U', 'pip'])
         if self.preinstall:
             subprocess.check_call(self.pip_preinstall(*self.preinstall))
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -119,12 +119,17 @@ few command line options:
    ``--preinstall`` argument. The replacement is expected to be found
    in the virtualenv's bin/ directory.
 
-.. cmdoption:: --upgrade-pip <package>
+.. cmdoption:: --upgrade-pip
 
    .. versionadded:: 1.0
 
-   Force upgrading pip to the latest available release. *Note:* This
-   can produce non-repeatable builds.
+   Force upgrading to the latest available release of ``pip``.
+   This is the first thing done in the preinstall stage,
+   and uses a separate ``pip`` call.
+   Options provided via ``--extra-pip-arg`` are ignored here,
+   since the default ``pip`` of your system might not support them.
+
+   *Note:* This can produce non-repeatable builds.
 
 .. cmdoption:: --index-url <URL>
 

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -24,7 +24,7 @@ import tempfile
 import textwrap
 import contextlib
 
-from mock import patch, call
+from mock import patch, call, ANY
 
 from nose.tools import eq_
 from dh_virtualenv import Deployment
@@ -171,7 +171,7 @@ def test_upgrade_pip(callmock):
     d.pip_args = ['install']
     d.install_dependencies()
     callmock.assert_called_with(
-        ['pip', 'install', '-U', 'pip'])
+        ['pip', 'install', ANY, '-U', 'pip'])
 
 
 @patch('subprocess.check_call')
@@ -181,7 +181,7 @@ def test_upgrade_pip_with_preinstall(callmock):
     d.pip_args = ['install']
     d.install_dependencies()
     callmock.assert_has_calls([
-        call(['pip', 'install', '-U', 'pip']),
+        call(['pip', 'install', ANY, '-U', 'pip']),
         call(['pip', 'install', 'foobar'])])
 
 


### PR DESCRIPTION
Includes doc fix: --upgrade-pip takes no argument