### PR TITLE
Run the tests on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,8 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 install: "pip install -r travis-requirements.txt"
 script: nosetests

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -186,7 +186,7 @@ class Deployment(object):
                    self.bin_dir]
         grep_proc = subprocess.Popen(command, stdout=subprocess.PIPE)
         files, stderr = grep_proc.communicate()
-        return files.strip().split('\n')
+        return files.decode('utf-8').strip().split('\n')
 
     def fix_shebangs(self):
         """Translate /usr/bin/python and /usr/bin/env python shebang

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -17,14 +17,25 @@
 # You should have received a copy of the GNU General Public License
 # along with dh-virtualenv. If not, see
 # <http://www.gnu.org/licenses/>.
+import io
 import os
 import warnings
-
-from StringIO import StringIO
 
 from dh_virtualenv import cmdline
 from mock import patch
 from nose.tools import eq_, ok_
+
+
+def get_mocked_stderr():
+    # optparse will try to print str(err) to sys.stderr, both on Python 2 and 3
+    # so we need to mock sys.stderr with the right *IO class
+    if str == bytes:
+        # We're on Python 2, where str(foo) is a bytes string
+        return io.BytesIO()
+
+    else:
+        # We're on Python 3, where str(foo) is a unicode string
+        return io.StringIO()
 
 
 @patch.object(cmdline.DebhelperOptionParser, 'error')
@@ -91,7 +102,7 @@ def test_no_test_creates_deprecation_warning():
 @patch('sys.exit')
 def test_pypi_url_index_url_conflict(exit_):
     parser = cmdline.get_default_parser()
-    f = StringIO()
+    f = get_mocked_stderr()
     with patch('sys.stderr', f):
         parser.parse_args([
             '--pypi-url=http://example.com',
@@ -105,7 +116,7 @@ def test_pypi_url_index_url_conflict(exit_):
 @patch('sys.exit')
 def test_test_flag_conflict(exit_):
     parser = cmdline.get_default_parser()
-    f = StringIO()
+    f = get_mocked_stderr()
     with patch('sys.stderr', f):
         parser.parse_args([
             '--no-test',
@@ -120,7 +131,7 @@ def test_test_flag_conflict(exit_):
 @patch('sys.exit')
 def test_pypi_url_index_url_conflict_independent_from_order(exit_):
     parser = cmdline.get_default_parser()
-    f = StringIO()
+    f = get_mocked_stderr()
     with patch('sys.stderr', f):
         parser.parse_args([
             '--index-url=http://example.org',

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -368,7 +368,7 @@ def test_fix_activate_path():
         deployment.fix_activate_path()
 
     with open(temp.name) as fh:
-        eq_(expected, temp.read())
+        eq_(expected, fh.read())
 
 
 @patch('os.path.exists', lambda x: True)


### PR DESCRIPTION
While trying to add tests for #201, I ran them on Python 3, out of habit, and found they failed.

The first few commits in this pull request fix the code so that all tests pass on Python 2 and 3.

The last commit adds Python 3.4, 3.5 and 3.6 to the Travis CI config file.