### PR TITLE
Make postinst compatible with -u flag

### DIFF
--- a/autoscripts/postinst-dh-virtualenv
+++ b/autoscripts/postinst-dh-virtualenv
@@ -3,7 +3,7 @@ set -e
 #ARGS#
 
 # set to empty to enable verbose output
-test "$DH_VERBOSE" = "1" && DH_VENV_DEBUG="" || DH_VENV_DEBUG=:
+test "${DH_VERBOSE:-0}" = "1" && DH_VENV_DEBUG="" || DH_VENV_DEBUG=:
 $DH_VENV_DEBUG set -x
 
 


### PR DESCRIPTION
The usage of `$DH_VERBOSE` might trigger *unbound variable* errors when used along with the bash -u flag. This might happen when the script is included in a custom postinst expanding the `#DEBHELPER#` tag.

This can be fixed by providing a default value for `$DH_VERBOSE` (0, disabled) when expanding the variable using bash `${VAR:-}`:

From the docs:  https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html

> ${parameter:-word}
>
>   If parameter is unset or null, the expansion of word is substituted. Otherwise, the value of parameter is substituted.

This was making our custom postinst scripts to fail, which we bypassed temporarily by declaring `DH_VIRTUALENV=0` before the `#DEBHELPER#` tag.
