### PR TITLE
Gets global interpreter path avoiding hardcoding the value

### DIFF
--- a/autoscripts/postinst-dh-virtualenv
+++ b/autoscripts/postinst-dh-virtualenv
@@ -19,14 +19,17 @@ dh_venv_safe_interpreter_update() {
         test ! -L "$interpreter_path" || continue
         test -x "$interpreter_path" || continue
 
+        # get global interpreter path
+        local global_interpreter_path=$(which $pythonX_Y)
+
         # skip if already identical
-        if cmp "/usr/bin/$pythonX_Y" "$interpreter_path" >/dev/null 2>&1; then
+        if cmp "$global_interpreter_path" "$interpreter_path" >/dev/null 2>&1; then
             continue
         fi
 
         # hardlink or copy new interpreter
-        cp -fpl "/usr/bin/$pythonX_Y" "$interpreter_path,new" \
-            || cp -fp "/usr/bin/$pythonX_Y" "$interpreter_path,new" \
+        cp -fpl "$global_interpreter_path" "$interpreter_path,new" \
+            || cp -fp "$global_interpreter_path" "$interpreter_path,new" \
             || rm -f "$interpreter_path,new" \
             || true
 


### PR DESCRIPTION
Postinst script assumes /usr/bin/python is the system python interpreter in use, this is ok in most cases, but in some specific cases where a different version could be installed in /usr/local/bin/python this could be a problem. This issue happened to me in a docker container based on the python base image. This image installs python 2.7.14 in /usr/local/bin/python, leaving the base python installation of the system in /usr/bin/python which comes from a lower version.