### PR TITLE
Disallow building the dh-virtualenv whilst within a virtualenv?

### DIFF
--- a/bin/dh_virtualenv
+++ b/bin/dh_virtualenv
@@ -65,6 +65,10 @@ def main():
         dh = DebHelper(packages=options.package or None)
     else:
         dh = DebHelper(options)
+    if hasattr(sys, 'real_prefix'):
+        log.error('Already in a virtualenv. This is likely to generate an '
+                  'invalid package (run "deactivate" first?)')
+        return 1
     for package, details in dh.packages.items():
         def _info(msg):
             log.info('{0}: {1}'.format(package, msg))


### PR DESCRIPTION
This prevents issues where the target virtual environment is not correctly setup, resulting in the lack of `sys.path` injection, etc.

I just spent a good few hours wondering why my deployed `.deb` was not setting the paths correctly; it was because I was building the Debian package locally within my *develoment* virtualenv. I'm not sure exactly what this broke (the `postinst` interpreter replacement logic?) but it meant that nothing could be imported as per usual.

(Rebuilding the deb after running `deactivate` immediately fixed it.)

Patch is somewhat blunt, mostly to describe the problem in code.. and it would at least prevent this particular corner case. (It might break your testsuite, mind you.)