### PR TITLE
Python3 venv bootstrap pip and setuptools with --system-site-package

### DIFF
--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -129,6 +129,7 @@ class Deployment(object):
         shutil.rmtree(self.debian_root)
 
     def create_virtualenv(self):
+        # Specify interpreter and virtual environment options
         if self.builtin_venv:
             virtualenv = [self.python, '-m', 'venv']
         else:
@@ -154,6 +155,15 @@ class Deployment(object):
 
         virtualenv.append(self.package_dir)
         subprocess.check_call(virtualenv)
+
+        # Due to Python bug https://bugs.python.org/issue24875
+        # venv doesn't bootstrap pip/setuptools in the virtual
+        # environment with --system-site-packages .
+        # The workaround is to reconfigure it with this option
+        # after it has been created.
+        if self.builtin_venv and self.use_system_packages:
+            virtualenv.append('--system-site-packages')
+            subprocess.check_call(virtualenv)
 
     def venv_bin(self, binary_name):
         return os.path.abspath(os.path.join(self.bin_dir, binary_name))

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -149,9 +149,9 @@ class Deployment(object):
             if self.python:
                 virtualenv.extend(('--python', self.python))
 
-            # Add in any user supplied pip args
-            if self.extra_virtualenv_arg:
-                virtualenv.extend(self.extra_virtualenv_arg)
+        # Add in any user supplied virtualenv args
+        if self.extra_virtualenv_arg:
+            virtualenv.extend(self.extra_virtualenv_arg)
 
         virtualenv.append(self.package_dir)
         subprocess.check_call(virtualenv)

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -199,9 +199,7 @@ few command line options:
    Enable the use of the build-in ``venv`` module, i.e. use ``python -m venv``
    to create the virtualenv. It will only work with Python 3.4 or later,
    e.g. by using the option
-   :option:`--python` ``/usr/bin/python3.4``. (Python 3.3 has the
-   ``venv`` module, but virtualenvs created with Python 3.3 are not
-   bootstrapped with setuptools or pip.)
+   :option:`--python` ``/usr/bin/python3.4``.
 
 .. option:: -S, --use-system-packages
 


### PR DESCRIPTION
Due to Python bug https://bugs.python.org/issue24875 the `venv` module does not install pip and setuptools when `--system-site-package` is used.

This has been fixed [upstream](https://github.com/python/cpython/blob/e42b705188271da108de42b55d9344642170aa2b/Lib/venv/__init__.py#L61) but has not been backported by distribution maintainers.

The accepted fix is to create the virtual environment first without `--system-site-package` allowing pip and setuptools to be installed and then reconfiguring the environment with `--system-site-package` to enable this option. This is also the recommend fix used by users on [Stack Overflow](https://stackoverflow.com/a/40989759/388127).

I recommend fixing this here in a similar way for consistency until the upstream fix has been rolled out. Otherwise virtual environments cannot use dependencies provided by the host, which might be preferred. In the event a future build system is running an interpreter with the fix, the penalty is the create step will run twice (due to the internal CPython fix).

As an alternative to this patch, users can add **all** dependencies to their `requirements.txt`, but those may differ from the system site version provided by the distribution.

Signed-off-by: Lucas Magasweran <lucas.magasweran@ieee.org>