### PR TITLE
Expand Python3 documentation

### DIFF
--- a/doc/howtos.rst
+++ b/doc/howtos.rst
@@ -45,7 +45,25 @@ And the Python update triggers in ``debian/«pkgname».triggers`` need to be ada
     interest-noawait /usr/bin/python3.5
     …
 
-That's all.
+You may also need to add the :option:`--python` option in ``debian/rules``.
+
+.. code-block:: make
+
+    %:
+        dh $@ --with python-virtualenv
+
+    override_dh_virtualenv:
+        dh_virtualenv --python python3
+
+If you're using the buildsystem alternative, it is instead specified through
+the :envvar:`DH_VIRTUALENV_ARGUMENTS` variable.
+
+.. code-block:: make
+
+    export DH_VIRTUALENV_ARGUMENTS := --no-site-packages --python python3
+
+    %:
+        dh $@ --buildsystem dh_virtualenv
 
 
 .. _fhs-links:


### PR DESCRIPTION
I had to add the `--python` flag when packaging a Python3 application. Otherwise, the virtualenv was built with Python2, regardless of build dependencies and triggers.

The option needed to create a Python3 environments when using the squence method (`--with python-virtualenv`) is well-documented through the example projects. It's not explicitly included in the documentation itself, though.

The experimental buildsystem alternative has not been used in any of the showcased projects. While obvious in hindsight, I found myself digging around for a bit to find the proper way of creating a Python3 environment with it.

I suggest that both methods are added to the Python3 cookbook section.