### PR TITLE
add cmd option to force upgrade setuptools

### DIFF
--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -106,6 +106,8 @@ def get_default_parser():
                       "the virtualenv's bin/ directory.")
     parser.add_option('--upgrade-pip', action='store_true', default=False,
                       help='Upgrade pip to the latest available version')
+    parser.add_option('--upgrade-setuptools', action='store_true', default=False,
+                      help='Upgrade setuptools using pip to the latest available version')
     parser.add_option('--extra-pip-arg', action='append',
                       help='Extra args for the pip binary.'
                       'You can use this flag multiple times to pass in'

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -37,6 +37,7 @@ class Deployment(object):
                  extras=[],
                  pip_tool='pip',
                  upgrade_pip=False,
+                 upgrade_setuptools=False,
                  index_url=None,
                  setuptools=False,
                  python=None,
@@ -70,6 +71,7 @@ class Deployment(object):
         self.preinstall = preinstall
         self.extras = extras
         self.upgrade_pip = upgrade_pip
+        self.upgrade_setuptools = upgrade_setuptools
         self.extra_virtualenv_arg = extra_virtualenv_arg
         self.log_file = tempfile.NamedTemporaryFile()
         self.verbose = verbose
@@ -98,7 +100,7 @@ class Deployment(object):
             '--extra-index-url={0}'.format(url) for url in extra_urls
         ])
         self.pip_args.append('--log={0}'.format(os.path.abspath(self.log_file.name)))
-        # Keep a copy with well-suported options only (for upgrading pip itself)
+        # Keep a copy with well-supported options only (for upgrading pip and setuptools)
         self.pip_upgrade_args = self.pip_args[:]
         # Add in any user supplied pip args
         self.pip_args.extend(extra_pip_arg)
@@ -112,6 +114,7 @@ class Deployment(object):
                    extras=options.extras,
                    pip_tool=options.pip_tool,
                    upgrade_pip=options.upgrade_pip,
+                   upgrade_setuptools=options.upgrade_setuptools,
                    index_url=options.index_url,
                    setuptools=options.setuptools,
                    python=options.python,
@@ -182,6 +185,8 @@ class Deployment(object):
         if self.upgrade_pip:
             # First, bootstrap pip with a reduced option set (well-supported options)
             subprocess.check_call(self.pip_preinstall_prefix + self.pip_upgrade_args + ['-U', 'pip'])
+        if self.upgrade_setuptools:
+            subprocess.check_call(self.pip_preinstall_prefix + self.pip_upgrade_args + ['-U', 'setuptools'])
         if self.preinstall:
             subprocess.check_call(self.pip_preinstall(*self.preinstall))
 

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -210,6 +210,16 @@ def test_upgrade_pip(callmock):
 
 
 @patch('subprocess.check_call')
+def test_upgrade_setuptools(callmock):
+    d = Deployment('test', upgrade_setuptools=True)
+    d.pip_prefix = d.pip_preinstall_prefix = ['pip']
+    d.pip_args = ['install']
+    d.install_dependencies()
+    callmock.assert_called_with(
+        ['pip', 'install', ANY, '-U', 'setuptools'])
+
+
+@patch('subprocess.check_call')
 def test_upgrade_pip_with_preinstall(callmock):
     d = Deployment('test', upgrade_pip=True, preinstall=['foobar'])
     d.pip_prefix = d.pip_preinstall_prefix = ['pip']


### PR DESCRIPTION
Add a command line option to force upgrading setuptools to the latest available version in the virtualenv. It seems to be possible using `--buildsystem=dh_virtualenv` but the doc says experimental.