### PR TITLE
Depends: python3-venv is a valid alternative to python-virtualenv

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Homepage: http://www.github.com/spotify/dh-virtualenv
 Package: dh-virtualenv
 Architecture: all
 Depends: ${python:Depends}, ${misc:Depends}, ${sphinxdoc:Depends},
- virtualenv | python-virtualenv (>= 1.7)
+ virtualenv | python-virtualenv (>= 1.7) | python3-venv
 Description: wrap and build python packages using virtualenv
  This package provides a dh sequencer that helps you to deploy your
  virtualenv wrapped installation inside a Debian package.


### PR DESCRIPTION
Make `--builtin-venv` usable in a sensible way.