### PR TITLE
Support venv options for builtin venv

### DIFF
--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -144,13 +144,13 @@ class Deployment(object):
         else:
             virtualenv = ['virtualenv']
 
-            if self.python:
-                virtualenv.extend(('--python', self.python))
-
             if self.use_system_packages:
                 virtualenv.append('--system-site-packages')
             else:
-                virtualenv.append('--no-site-packages')
+                virtualenv.append('--no-site-packages')            
+            
+            if self.python:
+                virtualenv.extend(('--python', self.python))
 
         if self.setuptools:
             virtualenv.append('--setuptools')

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -137,22 +137,26 @@ class Deployment(object):
         # Specify interpreter and virtual environment options
         if self.builtin_venv:
             virtualenv = [self.python, '-m', 'venv']
+
+            if self.use_system_packages:
+                virtualenv.append('--system-site-packages')
+
         else:
             virtualenv = ['virtualenv']
+
+            if self.python:
+                virtualenv.extend(('--python', self.python))
 
             if self.use_system_packages:
                 virtualenv.append('--system-site-packages')
             else:
                 virtualenv.append('--no-site-packages')
 
-            if self.setuptools:
-                virtualenv.append('--setuptools')
+        if self.setuptools:
+            virtualenv.append('--setuptools')
 
-            if self.verbose:
-                virtualenv.append('--verbose')
-
-            if self.python:
-                virtualenv.extend(('--python', self.python))
+        if self.verbose:
+            virtualenv.append('--verbose')
 
         # Add in any user supplied virtualenv args
         if self.extra_virtualenv_arg:


### PR DESCRIPTION
Previously, these options were only available to the external `virtualenv` tool.