### PR TITLE
Add --pip-logfile option

### DIFF
--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -154,6 +154,11 @@ def get_default_parser():
                       action='callback',
                       help='Run `setup.py test` when building the package',
                       callback=_check_for_deprecated_options)
+    parser.add_option('--pip-logfile',
+                      dest='pip_logfile',
+                      default=None,
+                      help='Set a specific file for pip logging, '
+                           'use `-` to log to standard output')
 
     # Ignore user-specified option bundles
     parser.add_option('-O', help=SUPPRESS_HELP)

--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -156,6 +156,7 @@ def get_default_parser():
                       callback=_check_for_deprecated_options)
     parser.add_option('--pip-logfile',
                       dest='pip_logfile',
+                      metavar='FILEPATH',
                       default=None,
                       help='Set a specific file for pip logging, '
                            'use `-` to log to standard output')

--- a/doc/dh_virtualenv.1.rst
+++ b/doc/dh_virtualenv.1.rst
@@ -45,6 +45,7 @@ OPTIONS
 --preinstall=PACKAGE			Preinstall a PACKAGE before running pip.
 --pip-tool=PIP_TOOL			Tool used to install requirements.
 --extra-pip-arg				Extra arg for the pip executable.
+--pip-logfile				Use specific log file for the pip executable
 --extra-virtualenv-arg			Extra arg for the virtualenv executable.
 --index-url				Base URL for PyPI server.
 --setuptools				Use setuptools instead of distribute.

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -176,6 +176,13 @@ few command line options:
    you need to change the behaviour of virtualenv during the packaging process.
    You can use this flag multiple times to pass in different virtualenv flags.
 
+.. option:: --pip-logfile <FILENAME>
+
+   Specific log file passed on to the pip executable. Use `-` (or `/dev/stdout`)
+   to disable file logging (pip output will be sent to standard output).
+
+   The default behaviour is to create a random temporary log file.
+
 .. option:: --requirements <REQUIREMENTS FILE>
 
    Use a different requirements file when installing. Some packages

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -326,6 +326,18 @@ def test_create_venv_with_extra_pip_arg(callmock):
     eq_(['install', LOG_ARG, '--no-compile'], d.pip_args)
 
 
+@patch('subprocess.check_call')
+def test_create_venv_without_log_file(callmock):
+    d = Deployment('test', pip_logfile='-')
+    d.create_virtualenv()
+    d.install_dependencies()
+    eq_('debian/test/opt/venvs/test', d.package_dir)
+    callmock.assert_called_with(['virtualenv', '--no-site-packages',
+                                 'debian/test/opt/venvs/test'])
+    eq_([PY_CMD, PIP_CMD], d.pip_prefix)
+    eq_(['install'], d.pip_args)
+
+
 @patch('tempfile.NamedTemporaryFile', FakeTemporaryFile)
 @patch('subprocess.check_call')
 def test_create_venv_with_setuptools(callmock):


### PR DESCRIPTION
This option may be used to suppress logging to a file (pip will print to
standard output), or specify a custom log file instead of the default
random one.