### PR TITLE
Feature: postinstall

### DIFF
--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -95,6 +95,10 @@ def get_default_parser():
                       help=('Package(s) to install before processing '
                             'requirements.txt.'),
                       default=[])
+    parser.add_option('--postinstall', action='append', metavar='PACKAGE',
+                      help=('Package(s) to install after processing '
+                            'requirements.txt.'),
+                      default=[])
     parser.add_option('--extras', action='append', metavar='NAME',
                       help=('Activate one or more extras of the main package.'),
                       default=[])

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -34,6 +34,7 @@ class Deployment(object):
                  package,
                  extra_urls=[],
                  preinstall=[],
+                 postinstall=[],
                  extras=[],
                  pip_tool='pip',
                  upgrade_pip=False,
@@ -70,6 +71,7 @@ class Deployment(object):
         self.local_bin_dir = os.path.join(self.package_dir, 'local', 'bin')
 
         self.preinstall = preinstall
+        self.postinstall = postinstall
         self.extras = extras
         self.upgrade_pip = upgrade_pip
         self.upgrade_pip_to = upgrade_pip_to
@@ -112,6 +114,7 @@ class Deployment(object):
         return cls(package,
                    extra_urls=options.extra_index_url,
                    preinstall=options.preinstall,
+                   postinstall=options.postinstall,
                    extras=options.extras,
                    pip_tool=options.pip_tool,
                    upgrade_pip=options.upgrade_pip,
@@ -202,6 +205,9 @@ class Deployment(object):
         requirements_path = os.path.join(self.sourcedirectory, self.requirements_filename)
         if os.path.exists(requirements_path):
             subprocess.check_call(self.pip('-r', requirements_path))
+
+        if self.postinstall:
+            subprocess.check_call(self.pip(*self.postinstall))
 
     def run_tests(self):
         python = self.venv_bin('python')

--- a/doc/howtos.rst
+++ b/doc/howtos.rst
@@ -344,3 +344,20 @@ See :ref:`example-configsite` for the full project that uses this.
    — with input from `@Nadav-Ruskin`_
 
 .. _`@Nadav-Ruskin`: https://github.com/Nadav-Ruskin
+
+
+.. _postinstall:
+
+Post-installing Packages
+========================
+
+Including `optional install flags`_ for ``pip`` within the requirements file causes builds to 
+avoid wheel packages, which is often undesireable. The ``--postinstall`` option allows
+packages to be installed after the main requirements, where their ``pip`` flags will
+not affect the broader requirements.
+
+.. code-block:: make
+
+    dh_virtualenv --postinstall "foobar==1.0 --install-option=--fuzzbar"
+
+.. _`optional_install_flags`: https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-install-option

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -113,6 +113,14 @@ few command line options:
    to parse ``setup.py``, and can be provided multiple times to
    pass multiple packages for pre-install.
 
+.. option:: --postinstall <package>
+
+    Package to install after processing the requirements. This flag
+    can be used to provide a package that is installed by ``pip``.
+    This is useful when additional ``pip`` commands are needed to install
+    a package (e.g. ``--install-option``), which would otherwise cause
+    packages in the requirements to not use wheel builds.
+
 .. option:: --extras <name>
 
    .. versionadded:: 1.1

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -236,13 +236,13 @@ def test_install_dependencies_with_preinstall_with_requirements(callmock):
 @patch('os.path.exists', lambda x: True)
 @patch('subprocess.check_call')
 def test_install_dependencies_with_requirements_with_postinstall(callmock):
-    d = Deployment('test', postinstall=['foobar==1.0 --install-option=--compile'])
+    d = Deployment('test', postinstall=['foobar==1.0 --install-option=--fuzzbar'])
     d.pip_prefix = ['pip']
     d.pip_args = ['install']
     d.install_dependencies()
     callmock.assert_has_calls([
         call(['pip', 'install', '-r', './requirements.txt']),
-        call(['pip', 'install', 'foobar==1.0 --install-option=--compile'])
+        call(['pip', 'install', 'foobar==1.0 --install-option=--fuzzbar'])
     ])
 
 

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -233,6 +233,19 @@ def test_install_dependencies_with_preinstall_with_requirements(callmock):
     ])
 
 
+@patch('os.path.exists', lambda x: True)
+@patch('subprocess.check_call')
+def test_install_dependencies_with_requirements_with_postinstall(callmock):
+    d = Deployment('test', postinstall=['foobar==1.0 --install-option=--compile'])
+    d.pip_prefix = ['pip']
+    d.pip_args = ['install']
+    d.install_dependencies()
+    callmock.assert_has_calls([
+        call(['pip', 'install', '-r', './requirements.txt']),
+        call(['pip', 'install', 'foobar==1.0 --install-option=--compile'])
+    ])
+
+
 @patch('os.path.exists', return_value=True)
 @patch('tempfile.NamedTemporaryFile', FakeTemporaryFile)
 @patch('subprocess.check_call')


### PR DESCRIPTION
Thanks for developing this package!

Currently the `dh_virtualenv` command will install the `requirements.txt` without wheels if [optional install flags](https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-install-option) are provided. Specifically I have seen this with `--install-option=...`, when included in the requirements file. This PR implements a postinstall feature, that provides a final `pip` command that can contain these flags for specific packages, without affecting the other packages in `requirements.txt`. Since the preinstall only covers a small number of packages, this new postinstall options is needed to ensure that the bulk of requirements are able to be installed as wheels before the postinstall occurs.

### TODO:
- [ ] Test this feature on actual dh_virtualenv packages