### PR TITLE
Updating Python support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 install: "pip install -r travis-requirements.txt"
 script: nosetests

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py34,py35
+envlist = py27,py35,py36,py37,py38
 
 
 [testenv]


### PR DESCRIPTION
This PR updates support for Python versions. Specifically it adds Python 3.7 and 3.8 to the CI, and drops Python 2.6 ([EOL October 29, 2013](https://www.python.org/dev/peps/pep-0361/#release-schedule)) and Python 3.4 ([EOL March 18, 2019](https://www.python.org/dev/peps/pep-0429/#id4)). This change is needed to fix the builds for #286, since Python 2.6 can not be downloaded.