### PR TITLE
debhelper.py: fix minor python3 incompatibility

### DIFF
--- a/dh_virtualenv/debhelper.py
+++ b/dh_virtualenv/debhelper.py
@@ -91,7 +91,7 @@ class DebHelper(object):
             log.error('Please remove XS-Python-Version from debian/control')
 
         log.debug('source=%s, binary packages=%s', self.source_name, \
-                                                   self.packages.keys())
+                                                   list(self.packages.keys()))
 
     def addsubstvar(self, package, name, value):
         """debhelper's addsubstvar"""


### PR DESCRIPTION
While dict.keys is a list in Python2 it is a "set-like object" in
Python3. To keep the output invariant when switching to Python3
explicitly convert to a list.