### PR TITLE
dh_virtualenv/deployment.py: fix virtualenv options

### DIFF
--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -77,6 +77,28 @@ def _check_for_deprecated_options(
         setattr(parser.values, '_test_flag_seen', True)
 
 
+def _set_builtin_venv(
+    option, opt_str, value, parser, *args, **kwargs
+):
+    if parser.values.setuptools:
+        raise OptionValueError(
+            '--setuptools flag is not supported by builtin venv module'
+        )
+    else:
+        parser.values.builtin_venv = True
+
+
+def _set_setuptools(
+    option, opt_str, value, parser, *args, **kwargs
+):
+    if parser.values.builtin_venv:
+        raise OptionValueError(
+            '--setuptools flag is not supported by builtin venv module'
+        )
+    else:
+        parser.values.setuptools = True
+
+
 def get_default_parser():
     usage = '%prog [options]'
     parser = DebhelperOptionParser(usage, version='%prog ' + version)
@@ -86,7 +108,9 @@ def get_default_parser():
                       help='Do not act on the specified package(s)')
     parser.add_option('-v', '--verbose', action='store_true',
                       default=False, help='Turn on verbose mode')
-    parser.add_option('-s', '--setuptools', action='store_true',
+    parser.add_option('-s', '--setuptools', action='callback',
+                      dest='setuptools',
+                      callback=_set_setuptools,
                       default=False, help='Use Setuptools instead of Distribute')
     parser.add_option('--extra-index-url', action='append', metavar='URL',
                       help='Extra index URL(s) to pass to pip.',
@@ -124,7 +148,9 @@ def get_default_parser():
                       callback=_check_for_deprecated_options)
     parser.add_option('--python', metavar='EXECUTABLE',
                       help='The Python command to use')
-    parser.add_option('--builtin-venv', action='store_true',
+    parser.add_option('--builtin-venv', action='callback',
+                      dest='builtin_venv',
+                      callback=_set_builtin_venv,
                       help='Use the built-in venv module. Only works on '
                       'Python 3.4 and later.')
     parser.add_option('-D', '--sourcedirectory', dest='sourcedirectory',

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -150,11 +150,11 @@ class Deployment(object):
             if self.python:
                 virtualenv.extend(('--python', self.python))
 
-        if self.setuptools:
-            virtualenv.append('--setuptools')
+            if self.setuptools:
+                virtualenv.append('--setuptools')
 
-        if self.verbose:
-            virtualenv.append('--verbose')
+            if self.verbose:
+                virtualenv.append('--verbose')
 
         # Add in any user supplied virtualenv args
         if self.extra_virtualenv_arg:

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,6 +8,11 @@ For a full list, consult the `git history`_ of the project.
 .. _`git history`: https://github.com/spotify/dh-virtualenv/commits/master
 
 
+Unreleased
+==========
+
+* Fix --verbose and --setuptools command line argument usage together with --builtin-venv
+
 1.2.2
 =====
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -189,6 +189,7 @@ few command line options:
 .. option:: --setuptools
 
    Use setuptools instead of distribute in the virtualenv.
+   Not supported when using builtin `venv` module with :option:`--builtin-venv`.
 
 .. option:: --setuptools-test
 

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -170,3 +170,19 @@ def test_that_use_system_packages_option_can_be_true():
     parser = cmdline.get_default_parser()
     opts, args = parser.parse_args(['--use-system-packages'])
     eq_(True, opts.use_system_packages)
+
+
+def test_builtin_venv_and_setuptools_conflict():
+    error_message = '--setuptools flag is not supported by builtin venv module'
+    args_list = [
+        ['--builtin-venv', '--setuptools'],
+        ['--setuptools', '--builtin-venv'],
+    ]
+
+    for args in args_list:
+        f = get_mocked_stderr()
+        with patch('sys.stderr', f), patch('sys.exit') as sysexit:
+            parser = cmdline.get_default_parser()
+            parser.parse_args(args)
+            ok_(error_message in f.getvalue())
+            sysexit.assert_called_once_with(2)

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -355,6 +355,20 @@ def test_venv_with_custom_python(callmock):
 
 @patch('tempfile.NamedTemporaryFile', FakeTemporaryFile)
 @patch('subprocess.check_call')
+def test_create_builtin_venv_with_unsupported_options(callmock):
+    d = Deployment(
+        'test', python='python_interpreter',
+        builtin_venv=True, setuptools=True, verbose=True
+    )
+    d.create_virtualenv()
+    eq_(TEST_VENV_PATH, d.package_dir)
+    callmock.assert_called_with(
+        ['python_interpreter', '-m', 'venv', TEST_VENV_PATH]
+    )
+
+
+@patch('tempfile.NamedTemporaryFile', FakeTemporaryFile)
+@patch('subprocess.check_call')
 def test_install_package(callmock):
     d = Deployment('test')
     d.bin_dir = 'derp'


### PR DESCRIPTION
The built-in python3 venv has neither '--setuptools',
nor '--verbose' switch.