### PR TITLE
Also fix 'python' shebang lines

### DIFF
--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -210,7 +210,7 @@ class Deployment(object):
     def find_script_files(self):
         """Find list of files containing python shebangs in the bin directory"""
         command = ['grep', '-l', '-r',
-                   '-e', r'^#!.*bin/\(env \)\?{0}'.format(_PYTHON_INTERPRETERS_REGEX),
+                   '-e', r'^#!\(python\|.*bin/\(env \)\?{0}\)'.format(_PYTHON_INTERPRETERS_REGEX),
                    '-e', r"^'''exec.*bin/{0}".format(_PYTHON_INTERPRETERS_REGEX),
                    self.bin_dir]
         grep_proc = subprocess.Popen(command, stdout=subprocess.PIPE)
@@ -218,12 +218,12 @@ class Deployment(object):
         return set(f for f in files.decode('utf-8').strip().split('\n') if f)
 
     def fix_shebangs(self):
-        """Translate /usr/bin/python and /usr/bin/env python shebang
+        """Translate '/usr/bin/python', '/usr/bin/env python', and 'python' shebang
         lines to point to our virtualenv python.
         """
         pythonpath = os.path.join(self.virtualenv_install_dir, 'bin/python')
         for f in self.find_script_files():
-            regex = (r's-^#!.*bin/\(env \)\?{names}\"\?-#!{pythonpath}-;'
+            regex = (r's-^#!\(python\|.*bin/\(env \)\?{names}\"\?\)-#!{pythonpath}-;'
                      r"s-^'''exec'.*bin/{names}-'''exec' {pythonpath}-"
             ).format(names=_PYTHON_INTERPRETERS_REGEX, pythonpath=re.escape(pythonpath))
             p = subprocess.Popen(

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -210,7 +210,7 @@ class Deployment(object):
     def find_script_files(self):
         """Find list of files containing python shebangs in the bin directory"""
         command = ['grep', '-l', '-r',
-                   '-e', r'^#!\(python\|.*bin/\(env \)\?{0}\)'.format(_PYTHON_INTERPRETERS_REGEX),
+                   '-e', r'^#!\({0}\|.*bin/\(env \)\?{0}\)'.format(_PYTHON_INTERPRETERS_REGEX),
                    '-e', r"^'''exec.*bin/{0}".format(_PYTHON_INTERPRETERS_REGEX),
                    self.bin_dir]
         grep_proc = subprocess.Popen(command, stdout=subprocess.PIPE)
@@ -223,7 +223,7 @@ class Deployment(object):
         """
         pythonpath = os.path.join(self.virtualenv_install_dir, 'bin/python')
         for f in self.find_script_files():
-            regex = (r's-^#!\(python\|.*bin/\(env \)\?{names}\"\?\)-#!{pythonpath}-;'
+            regex = (r's-^#!\({names}\|.*bin/\(env \)\?{names}\"\?\)-#!{pythonpath}-;'
                      r"s-^'''exec'.*bin/{names}-'''exec' {pythonpath}-"
             ).format(names=_PYTHON_INTERPRETERS_REGEX, pythonpath=re.escape(pythonpath))
             p = subprocess.Popen(

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -12,6 +12,11 @@ Unreleased
 ==========
 
 * Fix --verbose and --setuptools command line argument usage together with --builtin-venv
+* Also fix ``#!python`` shebang lines
+  (`#317 <https://github.com/spotify/dh-virtualenv/pull/317>`_)
+  [`@blag <https://github.com/blag>`_, `@Kami <https://github.com/Kami>`_,
+  `@dennybaa <https://github.com/dennybaa>`_, and
+  `@StackStorm contributors <https://github.com/StackStorm>`_]
 
 1.2.2
 =====

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -131,6 +131,14 @@ def check_shebangs_fix(interpreter, path):
     with open(temp.name) as f:
         eq_(f.readline(), expected_shebang)
 
+    with open(temp.name, 'w') as f:
+        f.write('#!{0}\n'.format(interpreter))
+
+    deployment.fix_shebangs()
+
+    with open(temp.name) as f:
+        eq_(f.readline(), expected_shebang)
+
     # Additional test to check for paths wrapped in quotes because they contained space
     # Example:
     #           #!"/some/local/path/dest/path/bin/python"


### PR DESCRIPTION
Some Python scripts only have `#!python` shebang lines. They also need to be fixed to point to the virtualenv.

This PR expands the search to include files with the `#!python` shebang lines and adds sed syntax to rewrite them as well.

Cherry-picked from https://github.com/StackStorm/dh-virtualenv/commit/340be0ec851953532a620959678a440575982806, which cherry-picked https://github.com/StackStorm/dh-virtualenv/commit/bf43b0ae436c8caa67f24d545df8cfca70d3cb9a.