### PR TITLE
fix typo in Buildsystem dh_virtualenv.pm for DH_VIRTUALENV_INSTALL_SUFFIX

### DIFF
--- a/lib/Debian/Debhelper/Buildsystem/dh_virtualenv.pm
+++ b/lib/Debian/Debhelper/Buildsystem/dh_virtualenv.pm
@@ -150,7 +150,7 @@ sub install {
 
     if (defined $ENV{DH_VIRTUALENV_INSTALL_SUFFIX}) {
         $new_python = "$prefix/" . $ENV{DH_VIRTUALENV_INSTALL_SUFFIX} . "/bin/python";
-        my $curdir = "$destdir$prefix" . $ENV{DH_VIRTUALENV_INSTALL_SUFFIX} . "/bin/*";
+        my $curdir = "$destdir$prefix/" . $ENV{DH_VIRTUALENV_INSTALL_SUFFIX} . "/bin/*";
         @binaries = glob($curdir);
     } else {
         $new_python = "$prefix/$sourcepackage/bin/python";


### PR DESCRIPTION
- fix typo in `dh_virtualenv.pm` for `DH_VIRTUALENV_INSTALL_SUFFIX`