### PR TITLE
Add example for skipping all shared libraries

### DIFF
--- a/doc/howtos.rst
+++ b/doc/howtos.rst
@@ -116,6 +116,16 @@ extend your ``debian/rules`` file as outlined below.
 This example works for the Python data science stack
 – you have to list the packages that cause *you* trouble.
 
+To skip all shared libraries in all packages, you can do the following.
+
+.. code-block:: makefile
+
+    override_dh_strip:
+            dh_strip --exclude=/site-packages/
+
+    override_dh_shlibdeps:
+            dh_shlibdeps --exclude=/site-packages/
+
 .. _manylinux: https://github.com/pypa/manylinux
 .. _`PEP 513`: https://www.python.org/dev/peps/pep-0513/
 


### PR DESCRIPTION
When "Architecture: any" is set in debian/control, and Python packages with binary shared libraries are installed, dh_strip and dh_shlibdeps can fail or corrupt shared libraries in those packages.

The documentation already includes an example for skipping libraries individually, this change adds an example to skip everything under "site-packages".

---

I don't know if this is correct, but it seems to work OK for me with packages build and installed under the same arch and Debian version.

Thanks for the great project.