### PR TITLE
only use -O options if option is supported

### DIFF
--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -36,7 +36,7 @@ class DebhelperOptionParser(OptionParser):
 
     """
     def parse_args(self, args=None, values=None):
-        args = [o[2:] if o.startswith('-O-') else o
+        args = [o[2:] if (o.startswith('-O-') and self.has_option(o[2:])) else o
                 for o in self._get_args(args)]
         args.extend(os.environ.get('DH_OPTIONS', '').split())
         # Unfortunately OptionParser is an old style class :(

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -12,6 +12,8 @@ Unreleased
 ==========
 
 * Fix --verbose and --setuptools command line argument usage together with --builtin-venv
+* Ignore unknown options passed via -O (as intended according to the debhelper
+  man page).
 * Also fix ``#!python`` shebang lines
   (`#317 <https://github.com/spotify/dh-virtualenv/pull/317>`_)
   [`@blag <https://github.com/blag>`_, `@Kami <https://github.com/Kami>`_,

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -53,12 +53,18 @@ def test_test_debhelper_option_parsing():
     eq_([], args)
 
 
+def test_ignore_unknown_debhelper_options():
+    parser = cmdline.DebhelperOptionParser()
+    parser.add_option('-O')
+    opts, args = parser.parse_args(['-O--buildsystem=none'])
+    eq_([], args)
+
+
 def test_parser_picks_up_DH_OPTIONS_from_environ():
     with patch.dict(os.environ, {'DH_OPTIONS': '--sourcedirectory=/tmp/'}):
         parser = cmdline.get_default_parser()
         opts, args = parser.parse_args()
         eq_('/tmp/', opts.sourcedirectory)
-
 
 def test_get_default_parser():
     parser = cmdline.get_default_parser()


### PR DESCRIPTION
Only convert `-O--option`  to `--option` if the option is actually known to `dh_virtualenv`. The patch converts options if they are known to the optionparser and otherwise leaves them at with `-O`, effectively ignoring them.

This is intended by debhelper, see [man debhelper](https://manpages.debian.org/testing/debhelper/debhelper.7.en.html):

>        -O=option|bundle
>           This is used by dh(1) when passing user-specified options to all the commands it runs. If the command supports the specified option or option bundle, it will take effect. If the command does not support the option (or any part of an option bundle), it will be ignored.

This fixes various use cases,  e.g. using the dh_virtualenv sequence and a custom build system:

```Makefile
%:
	dh $@ --with=python-virtualenv --buildsystem=none
```

Without the patch dh_virtualenv fails:

```
bin/dh_virtualenv -O--buildsystem=none
Usage: dh_virtualenv [options]
```