### PR TITLE
docs: Fix a few typos

### DIFF
--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -45,7 +45,7 @@ class DebhelperOptionParser(OptionParser):
 
 def _check_for_deprecated_options(
         option, opt_str, value, parser, *args, **kwargs):
-    # TODO: If more deprectaed options pop up, refactor this method to
+    # TODO: If more deprecated options pop up, refactor this method to
     # handle them in more generic way (or actually remove the
     # deprecated options)
     if opt_str in ('--pypi-url', '--index-url'):

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -101,7 +101,7 @@ class Deployment(object):
             '--extra-index-url={0}'.format(url) for url in extra_urls
         ])
         self.pip_args.append('--log={0}'.format(os.path.abspath(self.log_file.name)))
-        # Keep a copy with well-suported options only (for upgrading pip itself)
+        # Keep a copy with well-supported options only (for upgrading pip itself)
         self.pip_upgrade_args = self.pip_args[:]
         # Add in any user supplied pip args
         self.pip_args.extend(extra_pip_arg)

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -20,7 +20,7 @@ debianized-sentry
 
 The project packages `Sentry.io`, adding systemd integration and default configuration
 for the Sentry Django/uWSGI app and related helper services.
-It also shows how to package 3rd party software as relased on PyPI,
+It also shows how to package 3rd party software as released on PyPI,
 keeping the packaging code separate from the packaged project.
 
 It is based on the `debianized-pypi-mold`_ cookiecutter, which allows you to set up

--- a/doc/howtos.rst
+++ b/doc/howtos.rst
@@ -75,7 +75,7 @@ To make executables in your virtualenv's ``bin`` directory callable from any she
 do **not** add that directory to the global ``PATH`` by a ``profile.d`` hook or similar.
 This would add all the other stuff in there too, and you simply do not want that.
 
-So use the ``debian/«pkgname».links`` file to add a symbolic link to *those* exectuables
+So use the ``debian/«pkgname».links`` file to add a symbolic link to *those* executables
 you want to be visible, typically the one created by your main application package.
 
 .. code-block:: ini

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -71,7 +71,7 @@ see the README for details on that.
 Using Docker also allows cross-distribution builds.
 
 Otherwise, after you have cloned the repository,
-you must install build tools and dependencies on your worksatation,
+you must install build tools and dependencies on your workstation,
 and then start the build:
 
 .. code-block:: bash


### PR DESCRIPTION
There are small typos in:
- dh_virtualenv/cmdline.py
- dh_virtualenv/deployment.py
- doc/examples.rst
- doc/howtos.rst
- doc/tutorial.rst

Fixes:
- Should read `workstation` rather than `worksatation`.
- Should read `supported` rather than `suported`.
- Should read `released` rather than `relased`.
- Should read `executables` rather than `exectuables`.
- Should read `deprecated` rather than `deprectaed`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md