### PR TITLE
Update for compatibility with Python 3.11

### DIFF
--- a/bin/dh_virtualenv
+++ b/bin/dh_virtualenv
@@ -57,7 +57,7 @@ def main():
     # passed the packages keyword argument. Newer (like Ubuntu
     # Precise) expect the whole options to be passed.
 
-    arguments = inspect.getargspec(DebHelper.__init__).args
+    arguments = inspect.getfullargspec(DebHelper.__init__).args
     if 'packages' in arguments:
         dh = DebHelper(packages=options.package or None)
     else:

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -19,6 +19,8 @@ Unreleased
   [`@blag <https://github.com/blag>`_, `@Kami <https://github.com/Kami>`_,
   `@dennybaa <https://github.com/dennybaa>`_, and
   `@StackStorm contributors <https://github.com/StackStorm>`_]
+* Replace usage of `inspect.getargspec` with `inspect.getfullargspec` for compatibility
+  with Python 3.11.
 
 1.2.2
 =====


### PR DESCRIPTION
`dh-virtualenv` is a tool that packages Python dependencies from PyPI into debian packages and run with the installee system's Python interpreter. `dh-virtualenv` relied on the `inspect.getargspec` method, which has been deprecated since Python 3.0. Finally, it appears that this method has been removed in Python 3.11.x, which Debian sid ships with.

This PR updates the check to use `inspect.getfullargspec` instead, which is [the suggested replacement](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec).

It's debatable whether this check is even still needed, but for now let's do the simple thing and update it to be compatible with modern Python versions.