### PR TITLE
remove usage of deprecated python3-mock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -qq -o Acquire::Languages=none \
         -yqq --no-install-recommends -o Dpkg::Options::=--force-unsafe-io \
         build-essential debhelper devscripts equivs lsb-release libparse-debianchangelog-perl \
         python3 python3-setuptools python3-pip python3-dev \
-        python3-sphinx python3-mock dh-exec dh-python python3-sphinx-rtd-theme \
+        python3-sphinx dh-exec dh-python python3-sphinx-rtd-theme \
     && if test "$(lsb_release -cs)" = 'bionic' ; then \
         apt-get install -yqq --no-install-recommends -o Dpkg::Options::=--force-unsafe-io \
                         -t bionic-backports debhelper; fi \

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: python
 Priority: optional
 Maintainer: Jyrki Pulliainen <jyrki@dywypi.org>
 Build-Depends: debhelper-compat (= 12), python3,
- python3-setuptools, python3-sphinx, python3-mock, dh-exec,
+ python3-setuptools, python3-sphinx, dh-exec,
  dh-python, libjs-jquery, libjs-underscore,
 # python-sphinx-rtd-theme doesn't exist in distributions
 # predating Debian Jessie and Ubuntu Xenial. On these legacy

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -20,9 +20,9 @@
 import io
 import os
 import warnings
+from unittest.mock import patch
 
 from dh_virtualenv import cmdline
-from mock import patch
 from nose.tools import eq_, ok_
 
 

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -23,8 +23,7 @@ import shutil
 import tempfile
 import textwrap
 import contextlib
-
-from mock import patch, call, ANY
+from unittest.mock import patch, call, ANY
 
 from nose.tools import eq_
 from dh_virtualenv import Deployment

--- a/travis-requirements.txt
+++ b/travis-requirements.txt
@@ -4,5 +4,4 @@ Pygments==2.7.2
 Sphinx==3.3.0
 sphinx-rtd-theme==0.5.0
 docutils==0.16
-mock==4.0.2
 nose==1.3.7


### PR DESCRIPTION

As says: https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards