### PR TITLE
Upgrade supported python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
-  - "3.6"
-  - "3.7"
-  - "3.8"
+  - "3.12"
+  - "3.13"
+  - "3.14"
 install: "pip install -r travis-requirements.txt"
-script: nosetests
+script: pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ ENV DEB_BUILD_OPTIONS=${opts}
 RUN apt-get update -qq -o Acquire::Languages=none \
     && env DEBIAN_FRONTEND=noninteractive apt-get install \
         -yqq --no-install-recommends -o Dpkg::Options::=--force-unsafe-io \
-        build-essential debhelper devscripts equivs lsb-release libparse-debianchangelog-perl \
+        build-essential debhelper devscripts equivs lsb-release \
         python3 python3-setuptools python3-pip python3-dev \
-        python3-sphinx python3-mock dh-exec dh-python python3-sphinx-rtd-theme \
+        python3-sphinx dh-exec dh-python python3-sphinx-rtd-theme \
     && if test "$(lsb_release -cs)" = 'bionic' ; then \
         apt-get install -yqq --no-install-recommends -o Dpkg::Options::=--force-unsafe-io \
                         -t bionic-backports debhelper; fi \

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ In the new sequence, `dh_virtualenv` is inserted right before `dh_installinit`.
 
 ## Running tests
 
-    $ nosetests ./test/test_deployment.py
+    $ pytest ./test/test_deployment.py
 
 
 ## Building the package in a Docker container

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: python
 Priority: optional
 Maintainer: Jyrki Pulliainen <jyrki@dywypi.org>
 Build-Depends: debhelper-compat (= 12), python3,
- python3-setuptools, python3-sphinx, python3-mock, dh-exec,
+ python3-setuptools, python3-sphinx, dh-exec,
  dh-python, libjs-jquery, libjs-underscore,
 # python-sphinx-rtd-theme doesn't exist in distributions
 # predating Debian Jessie and Ubuntu Xenial. On these legacy

--- a/debian/rules
+++ b/debian/rules
@@ -25,6 +25,6 @@ override_dh_gencontrol:
 
 ifeq (,$(findstring nodoc, $(DEB_BUILD_OPTIONS)))
 override_dh_installdocs:
-	python3 setup.py build_sphinx
-	dh_installdocs doc/_build/html
+	sphinx-build -b html doc doc/_build
+	dh_installdocs doc/_build
 endif

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,15 +4,15 @@
 
 # Developer tooling
 pip-upgrader
-invoke==0.13.0
-rituals==0.4.1
+invoke==2.2.1
+rituals==0.4.2
 #https://github.com/jhermann/rituals/archive/master.zip#egg=rituals
 
 # CI tooling
 -r travis-requirements.txt
 
 # Sphinx basics are in Travis requirements
-sphinx-autobuild==0.7.1
+sphinx-autobuild==2025.8.25
 
 # Add project itself
 -e .

--- a/doc/LICENSE.rst
+++ b/doc/LICENSE.rst
@@ -1,0 +1,349 @@
+Software License
+================
+
+    Copyright GNU General Public License v2 or later
+
+Full License Text
+-----------------
+
+::
+
+                        GNU GENERAL PUBLIC LICENSE
+                           Version 2, June 1991
+    
+     Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+     Everyone is permitted to copy and distribute verbatim copies
+     of this license document, but changing it is not allowed.
+    
+                                Preamble
+    
+      The licenses for most software are designed to take away your
+    freedom to share and change it.  By contrast, the GNU General Public
+    License is intended to guarantee your freedom to share and change free
+    software--to make sure the software is free for all its users.  This
+    General Public License applies to most of the Free Software
+    Foundation's software and to any other program whose authors commit to
+    using it.  (Some other Free Software Foundation software is covered by
+    the GNU Lesser General Public License instead.)  You can apply it to
+    your programs, too.
+    
+      When we speak of free software, we are referring to freedom, not
+    price.  Our General Public Licenses are designed to make sure that you
+    have the freedom to distribute copies of free software (and charge for
+    this service if you wish), that you receive source code or can get it
+    if you want it, that you can change the software or use pieces of it
+    in new free programs; and that you know you can do these things.
+    
+      To protect your rights, we need to make restrictions that forbid
+    anyone to deny you these rights or to ask you to surrender the rights.
+    These restrictions translate to certain responsibilities for you if you
+    distribute copies of the software, or if you modify it.
+    
+      For example, if you distribute copies of such a program, whether
+    gratis or for a fee, you must give the recipients all the rights that
+    you have.  You must make sure that they, too, receive or can get the
+    source code.  And you must show them these terms so they know their
+    rights.
+    
+      We protect your rights with two steps: (1) copyright the software, and
+    (2) offer you this license which gives you legal permission to copy,
+    distribute and/or modify the software.
+    
+      Also, for each author's protection and ours, we want to make certain
+    that everyone understands that there is no warranty for this free
+    software.  If the software is modified by someone else and passed on, we
+    want its recipients to know that what they have is not the original, so
+    that any problems introduced by others will not reflect on the original
+    authors' reputations.
+    
+      Finally, any free program is threatened constantly by software
+    patents.  We wish to avoid the danger that redistributors of a free
+    program will individually obtain patent licenses, in effect making the
+    program proprietary.  To prevent this, we have made it clear that any
+    patent must be licensed for everyone's free use or not licensed at all.
+    
+      The precise terms and conditions for copying, distribution and
+    modification follow.
+    
+                        GNU GENERAL PUBLIC LICENSE
+       TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+    
+      0. This License applies to any program or other work which contains
+    a notice placed by the copyright holder saying it may be distributed
+    under the terms of this General Public License.  The "Program", below,
+    refers to any such program or work, and a "work based on the Program"
+    means either the Program or any derivative work under copyright law:
+    that is to say, a work containing the Program or a portion of it,
+    either verbatim or with modifications and/or translated into another
+    language.  (Hereinafter, translation is included without limitation in
+    the term "modification".)  Each licensee is addressed as "you".
+    
+    Activities other than copying, distribution and modification are not
+    covered by this License; they are outside its scope.  The act of
+    running the Program is not restricted, and the output from the Program
+    is covered only if its contents constitute a work based on the
+    Program (independent of having been made by running the Program).
+    Whether that is true depends on what the Program does.
+    
+      1. You may copy and distribute verbatim copies of the Program's
+    source code as you receive it, in any medium, provided that you
+    conspicuously and appropriately publish on each copy an appropriate
+    copyright notice and disclaimer of warranty; keep intact all the
+    notices that refer to this License and to the absence of any warranty;
+    and give any other recipients of the Program a copy of this License
+    along with the Program.
+    
+    You may charge a fee for the physical act of transferring a copy, and
+    you may at your option offer warranty protection in exchange for a fee.
+    
+      2. You may modify your copy or copies of the Program or any portion
+    of it, thus forming a work based on the Program, and copy and
+    distribute such modifications or work under the terms of Section 1
+    above, provided that you also meet all of these conditions:
+    
+        a) You must cause the modified files to carry prominent notices
+        stating that you changed the files and the date of any change.
+    
+        b) You must cause any work that you distribute or publish, that in
+        whole or in part contains or is derived from the Program or any
+        part thereof, to be licensed as a whole at no charge to all third
+        parties under the terms of this License.
+    
+        c) If the modified program normally reads commands interactively
+        when run, you must cause it, when started running for such
+        interactive use in the most ordinary way, to print or display an
+        announcement including an appropriate copyright notice and a
+        notice that there is no warranty (or else, saying that you provide
+        a warranty) and that users may redistribute the program under
+        these conditions, and telling the user how to view a copy of this
+        License.  (Exception: if the Program itself is interactive but
+        does not normally print such an announcement, your work based on
+        the Program is not required to print an announcement.)
+    
+    These requirements apply to the modified work as a whole.  If
+    identifiable sections of that work are not derived from the Program,
+    and can be reasonably considered independent and separate works in
+    themselves, then this License, and its terms, do not apply to those
+    sections when you distribute them as separate works.  But when you
+    distribute the same sections as part of a whole which is a work based
+    on the Program, the distribution of the whole must be on the terms of
+    this License, whose permissions for other licensees extend to the
+    entire whole, and thus to each and every part regardless of who wrote it.
+    
+    Thus, it is not the intent of this section to claim rights or contest
+    your rights to work written entirely by you; rather, the intent is to
+    exercise the right to control the distribution of derivative or
+    collective works based on the Program.
+    
+    In addition, mere aggregation of another work not based on the Program
+    with the Program (or with a work based on the Program) on a volume of
+    a storage or distribution medium does not bring the other work under
+    the scope of this License.
+    
+      3. You may copy and distribute the Program (or a work based on it,
+    under Section 2) in object code or executable form under the terms of
+    Sections 1 and 2 above provided that you also do one of the following:
+    
+        a) Accompany it with the complete corresponding machine-readable
+        source code, which must be distributed under the terms of Sections
+        1 and 2 above on a medium customarily used for software interchange; or,
+    
+        b) Accompany it with a written offer, valid for at least three
+        years, to give any third party, for a charge no more than your
+        cost of physically performing source distribution, a complete
+        machine-readable copy of the corresponding source code, to be
+        distributed under the terms of Sections 1 and 2 above on a medium
+        customarily used for software interchange; or,
+    
+        c) Accompany it with the information you received as to the offer
+        to distribute corresponding source code.  (This alternative is
+        allowed only for noncommercial distribution and only if you
+        received the program in object code or executable form with such
+        an offer, in accord with Subsection b above.)
+    
+    The source code for a work means the preferred form of the work for
+    making modifications to it.  For an executable work, complete source
+    code means all the source code for all modules it contains, plus any
+    associated interface definition files, plus the scripts used to
+    control compilation and installation of the executable.  However, as a
+    special exception, the source code distributed need not include
+    anything that is normally distributed (in either source or binary
+    form) with the major components (compiler, kernel, and so on) of the
+    operating system on which the executable runs, unless that component
+    itself accompanies the executable.
+    
+    If distribution of executable or object code is made by offering
+    access to copy from a designated place, then offering equivalent
+    access to copy the source code from the same place counts as
+    distribution of the source code, even though third parties are not
+    compelled to copy the source along with the object code.
+    
+      4. You may not copy, modify, sublicense, or distribute the Program
+    except as expressly provided under this License.  Any attempt
+    otherwise to copy, modify, sublicense or distribute the Program is
+    void, and will automatically terminate your rights under this License.
+    However, parties who have received copies, or rights, from you under
+    this License will not have their licenses terminated so long as such
+    parties remain in full compliance.
+    
+      5. You are not required to accept this License, since you have not
+    signed it.  However, nothing else grants you permission to modify or
+    distribute the Program or its derivative works.  These actions are
+    prohibited by law if you do not accept this License.  Therefore, by
+    modifying or distributing the Program (or any work based on the
+    Program), you indicate your acceptance of this License to do so, and
+    all its terms and conditions for copying, distributing or modifying
+    the Program or works based on it.
+    
+      6. Each time you redistribute the Program (or any work based on the
+    Program), the recipient automatically receives a license from the
+    original licensor to copy, distribute or modify the Program subject to
+    these terms and conditions.  You may not impose any further
+    restrictions on the recipients' exercise of the rights granted herein.
+    You are not responsible for enforcing compliance by third parties to
+    this License.
+    
+      7. If, as a consequence of a court judgment or allegation of patent
+    infringement or for any other reason (not limited to patent issues),
+    conditions are imposed on you (whether by court order, agreement or
+    otherwise) that contradict the conditions of this License, they do not
+    excuse you from the conditions of this License.  If you cannot
+    distribute so as to satisfy simultaneously your obligations under this
+    License and any other pertinent obligations, then as a consequence you
+    may not distribute the Program at all.  For example, if a patent
+    license would not permit royalty-free redistribution of the Program by
+    all those who receive copies directly or indirectly through you, then
+    the only way you could satisfy both it and this License would be to
+    refrain entirely from distribution of the Program.
+    
+    If any portion of this section is held invalid or unenforceable under
+    any particular circumstance, the balance of the section is intended to
+    apply and the section as a whole is intended to apply in other
+    circumstances.
+    
+    It is not the purpose of this section to induce you to infringe any
+    patents or other property right claims or to contest validity of any
+    such claims; this section has the sole purpose of protecting the
+    integrity of the free software distribution system, which is
+    implemented by public license practices.  Many people have made
+    generous contributions to the wide range of software distributed
+    through that system in reliance on consistent application of that
+    system; it is up to the author/donor to decide if he or she is willing
+    to distribute software through any other system and a licensee cannot
+    impose that choice.
+    
+    This section is intended to make thoroughly clear what is believed to
+    be a consequence of the rest of this License.
+    
+      8. If the distribution and/or use of the Program is restricted in
+    certain countries either by patents or by copyrighted interfaces, the
+    original copyright holder who places the Program under this License
+    may add an explicit geographical distribution limitation excluding
+    those countries, so that distribution is permitted only in or among
+    countries not thus excluded.  In such case, this License incorporates
+    the limitation as if written in the body of this License.
+    
+      9. The Free Software Foundation may publish revised and/or new versions
+    of the General Public License from time to time.  Such new versions will
+    be similar in spirit to the present version, but may differ in detail to
+    address new problems or concerns.
+    
+    Each version is given a distinguishing version number.  If the Program
+    specifies a version number of this License which applies to it and "any
+    later version", you have the option of following the terms and conditions
+    either of that version or of any later version published by the Free
+    Software Foundation.  If the Program does not specify a version number of
+    this License, you may choose any version ever published by the Free Software
+    Foundation.
+    
+      10. If you wish to incorporate parts of the Program into other free
+    programs whose distribution conditions are different, write to the author
+    to ask for permission.  For software which is copyrighted by the Free
+    Software Foundation, write to the Free Software Foundation; we sometimes
+    make exceptions for this.  Our decision will be guided by the two goals
+    of preserving the free status of all derivatives of our free software and
+    of promoting the sharing and reuse of software generally.
+    
+                                NO WARRANTY
+    
+      11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+    FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+    OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+    PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+    OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+    TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+    PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+    REPAIR OR CORRECTION.
+    
+      12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+    WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+    REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+    INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+    OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+    TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+    YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+    PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGES.
+    
+                         END OF TERMS AND CONDITIONS
+    
+                How to Apply These Terms to Your New Programs
+    
+      If you develop a new program, and you want it to be of the greatest
+    possible use to the public, the best way to achieve this is to make it
+    free software which everyone can redistribute and change under these terms.
+    
+      To do so, attach the following notices to the program.  It is safest
+    to attach them to the start of each source file to most effectively
+    convey the exclusion of warranty; and each file should have at least
+    the "copyright" line and a pointer to where the full notice is found.
+    
+        <one line to give the program's name and a brief idea of what it does.>
+        Copyright (C) <year>  <name of author>
+    
+        This program is free software; you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation; either version 2 of the License, or
+        (at your option) any later version.
+    
+        This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
+    
+        You should have received a copy of the GNU General Public License along
+        with this program; if not, write to the Free Software Foundation, Inc.,
+        51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    
+    Also add information on how to contact you by electronic and paper mail.
+    
+    If the program is interactive, make it output a short notice like this
+    when it starts in an interactive mode:
+    
+        Gnomovision version 69, Copyright (C) year name of author
+        Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+        This is free software, and you are welcome to redistribute it
+        under certain conditions; type `show c' for details.
+    
+    The hypothetical commands `show w' and `show c' should show the appropriate
+    parts of the General Public License.  Of course, the commands you use may
+    be called something other than `show w' and `show c'; they could even be
+    mouse-clicks or menu items--whatever suits your program.
+    
+    You should also get your employer (if you work as a programmer) or your
+    school, if any, to sign a "copyright disclaimer" for the program, if
+    necessary.  Here is a sample; alter the names:
+    
+      Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+      `Gnomovision' (which makes passes at compilers) written by James Hacker.
+    
+      <signature of Ty Coon>, 1 April 1989
+      Ty Coon, President of Vice
+    
+    This General Public License does not permit incorporating your program into
+    proprietary programs.  If your program is a subroutine library, you may
+    consider it more useful to permit linking proprietary applications with the
+    library.  If this is what you want to do, use the GNU Lesser General
+    Public License instead of this License.

--- a/doc/api/dh_virtualenv.rst
+++ b/doc/api/dh_virtualenv.rst
@@ -2,27 +2,33 @@ dh\_virtualenv package
 ======================
 
 .. automodule:: dh_virtualenv
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
 
-dh\_virtualenv\.cmdline module
-------------------------------
+dh\_virtualenv.cmdline module
+-----------------------------
 
 .. automodule:: dh_virtualenv.cmdline
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
-dh\_virtualenv\.deployment module
----------------------------------
+dh\_virtualenv.debhelper module
+-------------------------------
+
+.. automodule:: dh_virtualenv.debhelper
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+dh\_virtualenv.deployment module
+--------------------------------
 
 .. automodule:: dh_virtualenv.deployment
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,0 @@
-[build_sphinx]
-source-dir = doc
-build-dir  = doc/_build
-all-files  = 1
-
-[upload_sphinx]
-upload-dir = doc/_build/html

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -22,8 +22,7 @@ import os
 import warnings
 
 from dh_virtualenv import cmdline
-from mock import patch
-from nose.tools import eq_, ok_
+from unittest.mock import patch
 
 
 def get_mocked_stderr():
@@ -42,29 +41,29 @@ def get_mocked_stderr():
 def test_unknown_argument_is_error(error_mock):
     parser = cmdline.DebhelperOptionParser(usage='foo')
     parser.parse_args(['-f'])
-    eq_(1, error_mock.call_count)
+    assert 1 == error_mock.call_count
 
 
 def test_test_debhelper_option_parsing():
     parser = cmdline.DebhelperOptionParser()
     parser.add_option('--sourcedirectory')
     opts, args = parser.parse_args(['-O--sourcedirectory', '/tmp'])
-    eq_('/tmp', opts.sourcedirectory)
-    eq_([], args)
+    assert '/tmp' == opts.sourcedirectory
+    assert [] == args
 
 
 def test_ignore_unknown_debhelper_options():
     parser = cmdline.DebhelperOptionParser()
     parser.add_option('-O')
     opts, args = parser.parse_args(['-O--buildsystem=none'])
-    eq_([], args)
+    assert [] == args
 
 
 def test_parser_picks_up_DH_OPTIONS_from_environ():
     with patch.dict(os.environ, {'DH_OPTIONS': '--sourcedirectory=/tmp/'}):
         parser = cmdline.get_default_parser()
         opts, args = parser.parse_args()
-        eq_('/tmp/', opts.sourcedirectory)
+        assert '/tmp/' == opts.sourcedirectory
 
 def test_get_default_parser():
     parser = cmdline.get_default_parser()
@@ -72,8 +71,8 @@ def test_get_default_parser():
         '-O--sourcedirectory', '/tmp/foo',
         '--extra-index-url', 'http://example.com'
     ])
-    eq_('/tmp/foo', opts.sourcedirectory)
-    eq_(['http://example.com'], opts.extra_index_url)
+    assert '/tmp/foo' == opts.sourcedirectory
+    assert ['http://example.com'] == opts.extra_index_url
 
 
 def test_pypi_url_creates_deprecation_warning():
@@ -86,9 +85,9 @@ def test_pypi_url_creates_deprecation_warning():
         parser.parse_args([
             '--pypi-url=http://example.com',
         ])
-    eq_(len(w), 1)
-    ok_(issubclass(w[0].category, DeprecationWarning))
-    eq_(str(w[0].message), 'Use of --pypi-url is deprecated. Use --index-url instead')
+    assert len(w) == 1
+    assert issubclass(w[0].category, DeprecationWarning)
+    assert str(w[0].message) == 'Use of --pypi-url is deprecated. Use --index-url instead'
 
 
 def test_no_test_creates_deprecation_warning():
@@ -97,9 +96,9 @@ def test_no_test_creates_deprecation_warning():
         parser.parse_args([
             '--no-test',
         ])
-    eq_(len(w), 1)
-    ok_(issubclass(w[0].category, DeprecationWarning))
-    eq_(str(w[0].message),
+    assert len(w) == 1
+    assert issubclass(w[0].category, DeprecationWarning)
+    assert (str(w[0].message) ==
         'Use of --no-test is deprecated and has no effect. '
         'Use --setuptools-test if you want to execute '
         '`setup.py test` during package build.')
@@ -114,7 +113,7 @@ def test_pypi_url_index_url_conflict(exit_):
             '--pypi-url=http://example.com',
             '--index-url=http://example.org']
         )
-    ok_('Deprecated --pypi-url and the new --index-url are mutually exclusive'
+    assert ('Deprecated --pypi-url and the new --index-url are mutually exclusive'
         in f.getvalue())
     exit_.assert_called_once_with(2)
 
@@ -128,7 +127,7 @@ def test_test_flag_conflict(exit_):
             '--no-test',
             '--setuptools-test']
         )
-    ok_('Deprecated --no-test and the new --setuptools-test are mutually '
+    assert ('Deprecated --no-test and the new --setuptools-test are mutually '
         'exclusive'
         in f.getvalue())
     exit_.assert_called_once_with(2)
@@ -143,7 +142,7 @@ def test_pypi_url_index_url_conflict_independent_from_order(exit_):
             '--index-url=http://example.org',
             '--pypi-url=http://example.com']
         )
-    ok_('Deprecated --pypi-url and the new --index-url are mutually exclusive'
+    assert ('Deprecated --pypi-url and the new --index-url are mutually exclusive'
         in f.getvalue())
     exit_.assert_called_once_with(2)
 
@@ -151,31 +150,31 @@ def test_pypi_url_index_url_conflict_independent_from_order(exit_):
 def test_that_default_test_option_should_be_false():
     parser = cmdline.get_default_parser()
     opts, args = parser.parse_args()
-    eq_(False, opts.setuptools_test)
+    assert False == opts.setuptools_test
 
 
 def test_that_test_option_can_be_true():
     parser = cmdline.get_default_parser()
     opts, args = parser.parse_args(['--setuptools-test'])
-    eq_(True, opts.setuptools_test)
+    assert True == opts.setuptools_test
 
 
 def test_that_no_test_option_has_no_effect():
     parser = cmdline.get_default_parser()
     opts, args = parser.parse_args(['--no-test'])
-    eq_(False, opts.setuptools_test)
+    assert False == opts.setuptools_test
 
 
 def test_that_default_use_system_packages_option_should_be_false():
     parser = cmdline.get_default_parser()
     opts, args = parser.parse_args()
-    eq_(False, opts.use_system_packages)
+    assert False == opts.use_system_packages
 
 
 def test_that_use_system_packages_option_can_be_true():
     parser = cmdline.get_default_parser()
     opts, args = parser.parse_args(['--use-system-packages'])
-    eq_(True, opts.use_system_packages)
+    assert True == opts.use_system_packages
 
 
 def test_builtin_venv_and_setuptools_conflict():
@@ -190,5 +189,5 @@ def test_builtin_venv_and_setuptools_conflict():
         with patch('sys.stderr', f), patch('sys.exit') as sysexit:
             parser = cmdline.get_default_parser()
             parser.parse_args(args)
-            ok_(error_message in f.getvalue())
+            assert error_message in f.getvalue()
             sysexit.assert_called_once_with(2)

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -23,10 +23,10 @@ import shutil
 import tempfile
 import textwrap
 import contextlib
+import pytest
 
-from mock import patch, call, ANY
+from unittest.mock import patch, call, ANY
 
-from nose.tools import eq_
 from dh_virtualenv import Deployment
 from dh_virtualenv.cmdline import get_default_parser
 
@@ -74,34 +74,35 @@ def create_new_style_shebang(executable):
     return shebang
 
 
-def test_shebangs_fix():
+@pytest.mark.parametrize("interpreter", ['python', 'pypy', 'ipy', 'jython'])
+def test_shebangs_fix(interpreter):
     """Generate a test for each possible interpreter"""
-    for interpreter in ('python', 'pypy', 'ipy', 'jython'):
-        yield check_shebangs_fix, interpreter, '/opt/venvs/test'
+    check_shebangs_fix(interpreter, '/opt/venvs/test')
 
 
-def test_shebangs_fix_overridden_root():
+@pytest.mark.parametrize("interpreter", ['python', 'pypy', 'ipy', 'jython'])
+def test_shebangs_fix_overridden_root(interpreter):
     """Generate a test for each possible interpreter while overriding root"""
     with patch.dict(os.environ, {'DH_VIRTUALENV_INSTALL_ROOT': 'foo'}):
-        for interpreter in ('python', 'pypy', 'ipy', 'jython'):
-            yield check_shebangs_fix, interpreter, 'foo/test'
+        check_shebangs_fix(interpreter, 'foo/test')
 
 
-def test_shebangs_fix_special_chars_in_path():
+@pytest.mark.parametrize("interpreter", ['python', 'pypy', 'ipy', 'jython'])
+def test_shebangs_fix_special_chars_in_path(interpreter):
     """Shebang fix: Don't trip on special characters in path"""
     with patch.dict(
         os.environ,
-        {'DH_VIRTUALENV_INSTALL_ROOT': 'some-directory:with/special_chars'}):
-        for interpreter in ('python', 'pypy', 'ipy', 'jython'):
-            yield (check_shebangs_fix, interpreter,
-                   'some-directory:with/special_chars/test')
+        {'DH_VIRTUALENV_INSTALL_ROOT': 'some-directory:with/special_chars'}
+    ):
+        check_shebangs_fix(interpreter,
+                           'some-directory:with/special_chars/test')
 
 
 def test_shebangs_fix_new_pip_with_over_127_chars():
     """Shebang fix: Handle new pip with long shebangs"""
     with patch.dict(
         os.environ,
-        {'DH_VIRTUALENV_INSTALL_ROOT': 127 * 'p'}):
+            {'DH_VIRTUALENV_INSTALL_ROOT': 127 * 'p'}):
         check_shebangs_fix_on_new_pip(127 * 'p' + '/test')
 
 
@@ -121,7 +122,7 @@ def check_shebangs_fix(interpreter, path):
     deployment.fix_shebangs()
 
     with open(temp.name) as f:
-        eq_(f.read(), expected_shebang)
+        assert f.read() == expected_shebang
 
     with open(temp.name, 'w') as f:
         f.write('#!/usr/bin/env {0}\n'.format(interpreter))
@@ -129,7 +130,7 @@ def check_shebangs_fix(interpreter, path):
     deployment.fix_shebangs()
 
     with open(temp.name) as f:
-        eq_(f.readline(), expected_shebang)
+        assert f.readline() == expected_shebang
 
     with open(temp.name, 'w') as f:
         f.write('#!{0}\n'.format(interpreter))
@@ -137,7 +138,7 @@ def check_shebangs_fix(interpreter, path):
     deployment.fix_shebangs()
 
     with open(temp.name) as f:
-        eq_(f.readline(), expected_shebang)
+        assert f.readline() == expected_shebang
 
     # Additional test to check for paths wrapped in quotes because they contained space
     # Example:
@@ -152,7 +153,7 @@ def check_shebangs_fix(interpreter, path):
     deployment.fix_shebangs()
 
     with open(temp.name) as f:
-        eq_(f.readline(), expected_shebang)
+        assert f.readline() == expected_shebang
 
 
 def check_shebangs_fix_on_new_pip(path):
@@ -175,7 +176,7 @@ def check_shebangs_fix_on_new_pip(path):
     deployment.fix_shebangs()
 
     with open(temp.name) as f:
-        eq_(f.read(), expected_shebang)
+        assert f.read() == expected_shebang
 
 
 @patch('os.path.exists', lambda x: False)
@@ -264,7 +265,7 @@ def test_custom_pip_tool_used_for_installation(callmock, _):
 def test_create_venv(callmock):
     d = Deployment('test')
     d.create_virtualenv()
-    eq_(TEST_VENV_PATH, d.package_dir)
+    assert TEST_VENV_PATH == d.package_dir
     callmock.assert_called_with(['virtualenv', TEST_VENV_PATH])
 
 
@@ -273,7 +274,7 @@ def test_create_venv(callmock):
 def test_create_venv_with_verbose(callmock):
     d = Deployment('test', verbose=True)
     d.create_virtualenv()
-    eq_(TEST_VENV_PATH, d.package_dir)
+    assert TEST_VENV_PATH == d.package_dir
     callmock.assert_called_with(['virtualenv', '--verbose', TEST_VENV_PATH])
 
 
@@ -282,12 +283,12 @@ def test_create_venv_with_verbose(callmock):
 def test_create_venv_with_extra_urls(callmock):
     d = Deployment('test', extra_urls=['foo', 'bar'])
     d.create_virtualenv()
-    eq_(TEST_VENV_PATH, d.package_dir)
+    assert TEST_VENV_PATH == d.package_dir
     callmock.assert_called_with(['virtualenv', TEST_VENV_PATH])
-    eq_([PY_CMD, PIP_CMD], d.pip_prefix)
-    eq_(['install', '--extra-index-url=foo',
+    assert [PY_CMD, PIP_CMD] == d.pip_prefix
+    assert ['install', '--extra-index-url=foo',
          '--extra-index-url=bar',
-         LOG_ARG], d.pip_args)
+         LOG_ARG] == d.pip_args
 
 
 @patch('tempfile.NamedTemporaryFile', FakeTemporaryFile)
@@ -295,7 +296,7 @@ def test_create_venv_with_extra_urls(callmock):
 def test_create_venv_with_extra_virtualenv(callmock):
     d = Deployment('test', extra_virtualenv_arg=["--never-download"])
     d.create_virtualenv()
-    eq_(TEST_VENV_PATH, d.package_dir)
+    assert TEST_VENV_PATH == d.package_dir
     callmock.assert_called_with(['virtualenv', '--never-download', TEST_VENV_PATH])
 
 
@@ -305,14 +306,14 @@ def test_create_venv_with_custom_index_url(callmock):
     d = Deployment('test', extra_urls=['foo', 'bar'],
                    index_url='http://example.com/simple')
     d.create_virtualenv()
-    eq_(TEST_VENV_PATH, d.package_dir)
+    assert TEST_VENV_PATH == d.package_dir
     callmock.assert_called_with(['virtualenv', TEST_VENV_PATH])
-    eq_([PY_CMD, PIP_CMD], d.pip_prefix)
-    eq_(['install',
+    assert [PY_CMD, PIP_CMD] == d.pip_prefix
+    assert ['install',
          '--index-url=http://example.com/simple',
          '--extra-index-url=foo',
          '--extra-index-url=bar',
-         LOG_ARG], d.pip_args)
+         LOG_ARG] == d.pip_args
 
 
 @patch('tempfile.NamedTemporaryFile', FakeTemporaryFile)
@@ -321,10 +322,10 @@ def test_create_venv_with_extra_pip_arg(callmock):
     d = Deployment('test', extra_pip_arg=['--no-compile'])
     d.create_virtualenv()
     d.install_dependencies()
-    eq_(TEST_VENV_PATH, d.package_dir)
+    assert TEST_VENV_PATH == d.package_dir
     callmock.assert_called_with(['virtualenv', TEST_VENV_PATH])
-    eq_([PY_CMD, PIP_CMD], d.pip_prefix)
-    eq_(['install', LOG_ARG, '--no-compile'], d.pip_args)
+    assert [PY_CMD, PIP_CMD] == d.pip_prefix
+    assert ['install', LOG_ARG, '--no-compile'] == d.pip_args
 
 
 @patch('tempfile.NamedTemporaryFile', FakeTemporaryFile)
@@ -332,10 +333,10 @@ def test_create_venv_with_extra_pip_arg(callmock):
 def test_create_venv_with_setuptools(callmock):
     d = Deployment('test', setuptools=True)
     d.create_virtualenv()
-    eq_(TEST_VENV_PATH, d.package_dir)
+    assert TEST_VENV_PATH == d.package_dir
     callmock.assert_called_with(['virtualenv', '--setuptools', TEST_VENV_PATH])
-    eq_([PY_CMD, PIP_CMD], d.pip_prefix)
-    eq_(['install', LOG_ARG], d.pip_args)
+    assert [PY_CMD, PIP_CMD] == d.pip_prefix
+    assert ['install', LOG_ARG] == d.pip_args
 
 
 @patch('tempfile.NamedTemporaryFile', FakeTemporaryFile)
@@ -343,11 +344,11 @@ def test_create_venv_with_setuptools(callmock):
 def test_create_venv_with_system_packages(callmock):
     d = Deployment('test', use_system_packages=True)
     d.create_virtualenv()
-    eq_(TEST_VENV_PATH, d.package_dir)
+    assert TEST_VENV_PATH == d.package_dir
     callmock.assert_called_with(['virtualenv', '--system-site-packages',
                                  TEST_VENV_PATH])
-    eq_([PY_CMD, PIP_CMD], d.pip_prefix)
-    eq_(['install', LOG_ARG], d.pip_args)
+    assert [PY_CMD, PIP_CMD] == d.pip_prefix
+    assert ['install', LOG_ARG] == d.pip_args
 
 
 @patch('tempfile.NamedTemporaryFile', FakeTemporaryFile)
@@ -355,10 +356,10 @@ def test_create_venv_with_system_packages(callmock):
 def test_venv_with_custom_python(callmock):
     d = Deployment('test', python='/tmp/python')
     d.create_virtualenv()
-    eq_(TEST_VENV_PATH, d.package_dir)
+    assert TEST_VENV_PATH == d.package_dir
     callmock.assert_called_with(['virtualenv', '--python', '/tmp/python', TEST_VENV_PATH])
-    eq_([PY_CMD, PIP_CMD], d.pip_prefix)
-    eq_(['install', LOG_ARG], d.pip_args)
+    assert [PY_CMD, PIP_CMD] == d.pip_prefix
+    assert ['install', LOG_ARG] == d.pip_args
 
 
 @patch('tempfile.NamedTemporaryFile', FakeTemporaryFile)
@@ -369,7 +370,7 @@ def test_create_builtin_venv_with_unsupported_options(callmock):
         builtin_venv=True, setuptools=True, verbose=True
     )
     d.create_virtualenv()
-    eq_(TEST_VENV_PATH, d.package_dir)
+    assert TEST_VENV_PATH == d.package_dir
     callmock.assert_called_with(
         ['python_interpreter', '-m', 'venv', TEST_VENV_PATH]
     )
@@ -414,7 +415,7 @@ def test_fix_activate_path():
         deployment.fix_activate_path()
 
     with open(temp.name) as fh:
-        eq_(expected, fh.read())
+        assert expected == fh.read()
 
 
 @patch('os.path.exists', lambda x: True)
@@ -460,7 +461,7 @@ def test_testrunner(callmock):
 def test_testrunner_setuppy_not_found(callmock):
     d = Deployment('test')
     d.run_tests()
-    eq_(callmock.call_count, 0)
+    assert callmock.call_count == 0
 
 
 @patch('tempfile.NamedTemporaryFile', FakeTemporaryFile)
@@ -470,8 +471,8 @@ def test_deployment_from_options():
             '-O--pypi-url', 'http://example.org'
         ])
         d = Deployment.from_options('foo', options)
-        eq_(d.package, 'foo')
-        eq_(d.pip_args,
+        assert d.package == 'foo'
+        assert (d.pip_args ==
             ['install', '--index-url=http://example.org',
              '--extra-index-url=http://example.com', LOG_ARG])
 
@@ -481,8 +482,8 @@ def test_deployment_from_options_with_verbose():
             '--verbose'
         ])
         d = Deployment.from_options('foo', options)
-        eq_(d.package, 'foo')
-        eq_(d.verbose, True)
+        assert d.package == 'foo'
+        assert d.verbose == True
 
 
 @patch('os.environ.get')
@@ -490,81 +491,76 @@ def test_deployment_from_options_with_verbose_from_env(env_mock):
         env_mock.return_value = '1'
         options, _ = get_default_parser().parse_args([])
         d = Deployment.from_options('foo', options)
-        eq_(d.package, 'foo')
-        eq_(d.verbose, True)
+        assert d.package == 'foo'
+        assert d.verbose == True
 
 
-@temporary_dir
-def test_fix_local_symlinks(deployment_dir):
+def test_fix_local_symlinks(tmp_path):
         d = Deployment('testing')
-        d.package_dir = deployment_dir
+        d.package_dir = tmp_path
 
-        local = os.path.join(deployment_dir, 'local')
+        local = os.path.join(tmp_path, 'local')
         os.makedirs(local)
-        target = os.path.join(deployment_dir, 'sometarget')
+        target = os.path.join(tmp_path, 'sometarget')
         symlink = os.path.join(local, 'symlink')
         os.symlink(target, symlink)
 
         d.fix_local_symlinks()
-        eq_(os.readlink(symlink), '../sometarget')
+        assert os.readlink(symlink) == '../sometarget'
 
 
-@temporary_dir
-def test_fix_local_symlinks_with_relative_links(deployment_dir):
+def test_fix_local_symlinks_with_relative_links(tmp_path):
         # Runs shouldn't ruin the already relative symlinks.
         d = Deployment('testing')
-        d.package_dir = deployment_dir
+        d.package_dir = tmp_path
 
-        local = os.path.join(deployment_dir, 'local')
+        local = os.path.join(tmp_path, 'local')
         os.makedirs(local)
         symlink = os.path.join(local, 'symlink')
         os.symlink('../target', symlink)
 
         d.fix_local_symlinks()
-        eq_(os.readlink(symlink), '../target')
+        assert os.readlink(symlink) == '../target'
 
 
-@temporary_dir
-def test_fix_local_symlinks_does_not_blow_up_on_missing_local(deployment_dir):
+def test_fix_local_symlinks_does_not_blow_up_on_missing_local(tmp_path):
         d = Deployment('testing')
-        d.package_dir = deployment_dir
+        d.package_dir = tmp_path
         d.fix_local_symlinks()
 
 
-@temporary_dir
-def test_find_script_files_normal_shebang(bin_dir):
+def test_find_script_files_normal_shebang(tmp_path):
     d = Deployment('testing')
-    d.bin_dir = bin_dir
+    d.bin_dir = tmp_path
 
-    script_files = [os.path.join(bin_dir, s) for s in
+    script_files = [os.path.join(tmp_path, s) for s in
                     ('s1', 's2', 's3')]
     for script in script_files:
-        with open(os.path.join(bin_dir, script), 'w') as f:
+        with open(os.path.join(tmp_path, script), 'w') as f:
             f.write('#!/usr/bin/python\n')
 
-    with open(os.path.join(bin_dir, 'n1'), 'w') as f:
+    with open(os.path.join(tmp_path, 'n1'), 'w') as f:
         f.write('#!/bin/bash')
 
     found_files = sorted(d.find_script_files())
-    eq_(found_files, script_files)
+    assert found_files == script_files
 
 
-@temporary_dir
-def test_find_script_files_long_shebang(bin_dir):
+def test_find_script_files_long_shebang(tmp_path):
     d = Deployment('testing')
-    d.bin_dir = bin_dir
+    d.bin_dir = tmp_path
 
-    script_files = [os.path.join(bin_dir, s) for s in
+    script_files = [os.path.join(tmp_path, s) for s in
                     ('s1', 's2', 's3')]
     for script in script_files:
-        with open(os.path.join(bin_dir, script), 'w') as f:
+        with open(os.path.join(tmp_path, script), 'w') as f:
             # It does not really matter what we write into the
             # exec statement as executable here
             f.write(
                 create_new_style_shebang('/usr/bin/python'))
 
-    with open(os.path.join(bin_dir, 'n1'), 'w') as f:
+    with open(os.path.join(tmp_path, 'n1'), 'w') as f:
         f.write('#!/bin/bash')
 
     found_files = sorted(d.find_script_files())
-    eq_(found_files, script_files)
+    assert found_files == script_files

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-envlist = py27,py35,py36,py37,py38
+envlist = py312,py313,py314
 
 
 [testenv]
 deps = -r{toxinidir}/travis-requirements.txt
-commands = nosetests
+commands = pytest

--- a/travis-requirements.txt
+++ b/travis-requirements.txt
@@ -1,7 +1,6 @@
-Jinja2==2.11.2
-MarkupSafe==1.1.1
-Pygments==2.7.2
-Sphinx==3.3.0
-sphinx-rtd-theme==0.5.0
-docutils==0.16
+Jinja2==3.1.6
+MarkupSafe==3.0.3
+Pygments==2.19.2
+Sphinx==8.2.3
+sphinx-rtd-theme==3.0.2
 pytest==8.4.2

--- a/travis-requirements.txt
+++ b/travis-requirements.txt
@@ -4,5 +4,4 @@ Pygments==2.7.2
 Sphinx==3.3.0
 sphinx-rtd-theme==0.5.0
 docutils==0.16
-mock==4.0.2
-nose==1.3.7
+pytest==8.4.2


### PR DESCRIPTION
I wanted to add a feature in dh-virtualenv (installing deps from a pep751 pylock.toml file, see https://github.com/nautik1/dh-virtualenv/pull/1 ), so I though I would first make the tests pass with a recent python.

This MR
- changes tox & travis py versions to 3.12, 3.13 and 3.14
- switches tests to pytest, removes python3-mock
- updates doc-related dependencies

Tested

- [x] `tox` tests succeed with python 3.13
- [x] `pip install -r dev-requirements.txt && pytest` succeeds with python 3.13
- [x] `invoke docs` works, doc has not been reviewed in details but looks visually ok; added a generated `LICENSE.rst` file
- [x] deb docker build works, tested with `--build-arg distro=debian:trixie` (resulting deb package not thoroughly tested, used in a pretty basic way)

Note: could not run this in travis though